### PR TITLE
Fix Minor typo on validation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ if($validation->fails()) {
 ```php
 if($validation->fails()) {
   return Redirect::to('login')
-    ->with_errors($validator);
+    ->with_errors($validation);
 }
 ```
 


### PR DESCRIPTION
It stated with_errors($validator) but should be with_errors($validation), no?
