### PR TITLE
Make blockHelp() do nothing if no text is passed

### DIFF
--- a/libraries/ControlGroup.php
+++ b/libraries/ControlGroup.php
@@ -222,6 +222,10 @@ class ControlGroup
    */
   public function blockHelp($help, $attributes = array())
   {
+    
+    // If no help text, do nothing
+    if (empty($help)) return;
+    
     // Attempt to translate help text
     $help = Helpers::translate($help);
 


### PR DESCRIPTION
The use case would be something like this:

``` php
<?= Former::file('image')->blockHelp(empty($news)?null:'<img src="'.$news->img.'"/>') ?>
```

Basically, I'd like to use the ternary operator in the blockHelp() call to only show an image if I have the data for it.  And if I don't, I don't want the p tag created for blockHelp.
