### PR TITLE
added 'danger' type for buttons/submit/reset

### DIFF
--- a/src/Former/Framework.php
+++ b/src/Former/Framework.php
@@ -33,7 +33,7 @@ class Framework
   private static $types = array(
     'bootstrap' => array(
       'large', 'small', 'mini',
-      'block', 'info', 'inverse', 'link', 'primary', 'success', 'warning'),
+      'block', 'danger', 'info', 'inverse', 'link', 'primary', 'success', 'warning'),
   );
 
   /**


### PR DESCRIPTION
Former::danger_button() would create a default-styled button because the 'danger' type was missing  in Framework::$types.
