### PR TITLE
Fixed bug in mulitselect

### DIFF
--- a/src/Former/Fields/Select.php
+++ b/src/Former/Fields/Select.php
@@ -129,6 +129,11 @@ class Select extends \Former\Field
     // Multiselects
     if ($this->type == 'multiselect') {
       $this->multiple();
+
+      if(!isset($this->attributes['id'])) {
+        $this->attributes['id'] = $name;
+      }
+      
       $name .= '[]';
     }
 

--- a/tests/Select.test.php
+++ b/tests/Select.test.php
@@ -21,7 +21,7 @@ class SelectTest extends FormerTests
   public function testMultiselect()
   {
     $select = Former::multiselect('foo')->__toString();
-    $matcher = $this->cg('<select multiple="true" id="foo" name="foo"></select>');
+    $matcher = $this->cg('<select multiple="true" id="foo" name="foo[]"></select>');
 
     $this->assertEquals($matcher, $select);
   }


### PR DESCRIPTION
multiselect didn't append "[]" to the field name, so PHP doesn't handle the multiple values and just uses the last value selected.
