### PR TITLE
Adding the ability to disable the creation of control groups and labels on a per-field basis

### DIFF
--- a/src/Former/Field.php
+++ b/src/Former/Field.php
@@ -90,7 +90,8 @@ abstract class Field extends Traits\FormerObject
   {
     return
       Former::form()->type == 'inline' or
-      in_array($this->type, array('hidden', 'submit', 'button', 'reset'));
+      in_array($this->type, array('hidden', 'submit', 'button', 'reset')) or
+      isset($this->attributes['unwrapped']);
   }
 
   /**


### PR DESCRIPTION
This change lets you do this on a field:

```
<?=Former::text($id)->unwrapped()?>
```

... to disable the creation of the control-group and label on a single field.  Sometimes my whole form **isn't** inline but I want to present a field or two in a custom way with very particular HTML.

By the way, it's awesome that your bundle is setup to be so flexible that a change like this required only a single new line of code.
