### PR TITLE
Fix form method attribute

### DIFF
--- a/src/Former/Form/Form.php
+++ b/src/Former/Form/Form.php
@@ -231,6 +231,7 @@ class Form extends FormerObject
     // Add spoof method
     if ($this->method == 'PUT' or $this->method == 'DELETE') {
       $spoof = $this->former->hidden('_method', $this->method);
+      $this->method = 'POST';
     } else $spoof = null;
 
     return $this->open().$spoof;


### PR DESCRIPTION
This fix the form method attribute.

Before:

``` HTML
<form accept-charset="utf-8" class="form-horizontal" method="PUT"><input type="hidden" name="_method" value="PUT">
```

After:

``` HTML
<form accept-charset="utf-8" class="form-horizontal" method="POST"><input type="hidden" name="_method" value="PUT">
```
