### PR TITLE
fix fromQuery with __toString methods

### DIFF
--- a/src/Former/Helpers.php
+++ b/src/Former/Helpers.php
@@ -92,9 +92,7 @@ class Helpers
     // Automatically fetch Lang objects for people who store translated options lists
     // Same of unfetched queries
     if (method_exists($query, 'get')) $query = $query->get();
-    if ($query instanceof Collection) $query = $query->toArray();
-
-    if(!is_array($query)) $query = (array) $query;
+    if (!is_array($query) and !($query instanceof Collection)) $query = (array) $query;
 
     // Populates the new options
     foreach ($query as $model) {


### PR DESCRIPTION
[Agnostic]

I was using `Former::select('topic')->fromQuery(Topic::all())` where in my Topic.php model, I had __toString() defined.

But in your `queryToArray()` function, you convert Topic::all() into an array (using toArray()), which destroys all the methods (I think), hence when you try `method_exists($model, '__toString')`, it returns `false`.

I can't think of any time you'd want to apply toArray() to a Collection, so I just combined the two if statements.

P.S. I had a look at your tests, and I don't understand how to make tests, sorry. The relevant method is `testSelectEloquentMagicMethods`, but I think perhaps it's not reconstructing an Eloquent model exactly? (hence it passes the test).

Sorry, this is my first pull request :P
