### PR TITLE
fix withErros in Laravel3

### DIFF
--- a/src/Former/Former.php
+++ b/src/Former/Former.php
@@ -211,10 +211,11 @@ class Former
 
     // If we're given a raw Validator, go fetch the errors in it
     if(method_exists($validator, 'getMessages')) $errors = $validator->getMessages();
+    if($validator instanceof \Laravel\Validator) $errors = $validator->errors;
 
     // If we found errors, bind them to the form
     if(isset($errors)) $this->errors = $errors;
-    else $this->errors = $validator;
+    elseif($validator) $this->errors = $validator;
   }
 
   /**


### PR DESCRIPTION
In laravel 3, the following line does not work and does not show error message in the form. 

Former::withErrors($validation);

I modified the withErrors function to work in laravel 3.
