### PR TITLE
Added get errors from getMessageBag() for L4

### DIFF
--- a/src/Former/Former.php
+++ b/src/Former/Former.php
@@ -210,7 +210,6 @@ class Former
     if($this->app['session']->has('errors')) $errors = $this->app['session']->get('errors');
 
     // If we're given a raw Validator, go fetch the errors in it
-    if(method_exists($validator, 'getMessages')) $errors = $validator->getMessages();
     if(method_exists($validator, 'getMessageBag')) $errors = $validator->getMessageBag();
     if($validator instanceof \Laravel\Validator) $errors = $validator->errors;
 


### PR DESCRIPTION
Laravel 4 Validator class has  getMessageBag() instead of getMessages().

Call to getMessages() in Former->withErrors() is replaced with call to getMessageBag()
