### PR TITLE
Fix to don't encode some types

### DIFF
--- a/src/Former/Traits/FormerObject.php
+++ b/src/Former/Traits/FormerObject.php
@@ -58,7 +58,7 @@ abstract class FormerObject extends Element
     $this->setId();
 
     // Encode HTML value
-    if (!in_array($this->getType(), array('submit', 'link', 'reset', 'button')) && is_string($this->value)) {
+    if (!$this->isButton() && is_string($this->value)) {
       $this->value = Helpers::encode($this->value);
     }
 


### PR DESCRIPTION
e.g. &lt;button&gt;&amp;lt;i class=&quot;icon-ok-sign&quot;&amp;gt;&amp;lt;/i&amp;gt; Save&lt;/button&gt;
