### PR TITLE
Initialize a new Request with POST and GET params

### DIFF
--- a/src/Former/Facades/Agnostic.php
+++ b/src/Former/Facades/Agnostic.php
@@ -44,7 +44,7 @@ class Agnostic extends FormerBuilder
     });
 
     $app->singleton('Symfony\Component\HttpFoundation\Request', function($app) {
-      $request = new Request($_GET, $_POST);
+      $request = Request::createFromGlobals();
       $request->setSessionStore($app['session']);
 
       return $request;


### PR DESCRIPTION
This change will initialize a new
\Symfony\Component\HttpFoundation\Request with the POSTed and GETed
values. This will allow a form to repopulate data from either, without
calling Former::populate().
