### PR TITLE
Allow deep searching inside POST and GET

### DIFF
--- a/src/Former/Former.php
+++ b/src/Former/Former.php
@@ -243,7 +243,7 @@ class Former
   {
     $oldValue = $this->app['request']->old($name, $fallback);
 
-    return $this->app['request']->get($name, $oldValue);
+    return $this->app['request']->get($name, $oldValue, true);
   }
 
   /**

--- a/tests/Fields/CheckboxTest.php
+++ b/tests/Fields/CheckboxTest.php
@@ -193,9 +193,9 @@ class CheckboxTest extends FormerTests
 
   public function testCanRepopulateCheckboxesFromPost()
   {
-    $this->app->app['request']->shouldReceive('get')->with('foo', '')->andReturn('');
-    $this->app->app['request']->shouldReceive('get')->with('foo_0', '')->andReturn(true);
-    $this->app->app['request']->shouldReceive('get')->with('foo_1', '')->andReturn(false);
+    $this->app->app['request']->shouldReceive('get')->with('foo', '', true)->andReturn('');
+    $this->app->app['request']->shouldReceive('get')->with('foo_0', '', true)->andReturn(true);
+    $this->app->app['request']->shouldReceive('get')->with('foo_1', '', true)->andReturn(false);
 
     $checkboxes = $this->former->checkboxes('foo')->checkboxes('foo', 'bar')->__toString();
     $matcher = $this->controlGroup($this->matchCheckedCheckbox('foo_0', 'Foo').$this->matchCheckbox('foo_1', 'Bar'));
@@ -252,7 +252,7 @@ class CheckboxTest extends FormerTests
   public function testCanRepopulateCheckboxesOnSubmit()
   {
     $this->app->app['config'] = $this->app->getConfig(true, '', true);
-    $this->app->app['request']->shouldReceive('get')->with('foo', '')->andReturn('');
+    $this->app->app['request']->shouldReceive('get')->with('foo', '', true)->andReturn('');
 
     $checkbox = $this->former->checkbox('foo')->text('foo')->__toString();
     $matcher = $this->controlGroup(

--- a/tests/Fields/RadioTest.php
+++ b/tests/Fields/RadioTest.php
@@ -191,7 +191,7 @@ class RadioTest extends FormerTests
 
   public function testRepopulateFromPost()
   {
-    $this->app->app['request']->shouldReceive('get')->with('foo', '')->andReturn(0);
+    $this->app->app['request']->shouldReceive('get')->with('foo', '', true)->andReturn(0);
 
     $radios = $this->former->radios('foo')->radios('foo', 'bar')->__toString();
     $matcher = $this->controlGroup($this->matchCheckedRadio('foo', 'Foo', 0).$this->matchRadio('foo2', 'Bar', 1));


### PR DESCRIPTION
Searching deeply allows for multidimensional forms like:
    Former::text('root[nested]')
This patch will now populate this field from POST and GET (or
anything you supply to Former::populate()).

Also updates the tests to expect the $deep param.
