### PR TITLE
Pass required attributes parameter to function

### DIFF
--- a/src/Former/Form/Group.php
+++ b/src/Former/Form/Group.php
@@ -383,7 +383,7 @@ class Group extends Tag
     // Replace help text with error if any found
     $errors = $this->former->getErrors();
     if ($errors and $this->former->getOption('error_messages')) {
-      $inline = $this->former->getFramework()->createHelp($errors, $this->attributes);
+      $inline = $this->former->getFramework()->createHelp($errors);
     }
 
     return join(null, array($inline, $block));

--- a/src/Former/Framework/ZurbFoundation.php
+++ b/src/Former/Framework/ZurbFoundation.php
@@ -104,7 +104,7 @@ class ZurbFoundation extends Framework implements FrameworkInterface
   //////////////////////////// RENDER BLOCKS /////////////////////////
   ////////////////////////////////////////////////////////////////////
 
-  public function createHelp($text, $attributes)
+  public function createHelp($text, $attributes = array())
   {
     return Element::create('small', $text, $attributes);
   }


### PR DESCRIPTION
This fixes an issue with ZurbFoundation after a validation error where the createHelp() function isn't passed the required parameters.
