### PR TITLE
Fatal error when using Former::populate()

### DIFF
--- a/src/Former/Populator.php
+++ b/src/Former/Populator.php
@@ -181,7 +181,8 @@ class Populator
         return $model->$attribute;
     }
 
-    if (array_key_exists($attribute, (array) $model)) {
+    $model = (array) $model;
+    if (array_key_exists($attribute, $model)) {
       return $model[$attribute];
     }
 


### PR DESCRIPTION
"If the array key exists in the array casted model, search for that attribute in that same casted array."

Basically, a key is being searched for in a casted array, but when that value is actually attempted to be retrieved, it's no longer on the casted array but the original variable (which can be an object).
