### PR TITLE
Expanded regular expression in getErrors to accept a wider range of keys

### DIFF
--- a/src/Former/Former.php
+++ b/src/Former/Former.php
@@ -430,7 +430,7 @@ class Former
 
     // Get name and translate array notation
     if(!$name) $name = $this->field->getName();
-    $name = preg_replace('/\[([a-z]+)\]/', '.$1', $name);
+    $name = preg_replace('/\[([0-9a-z_\-]+)\]/', '.$1', $name);
 
     if ($this->errors) {
       return $this->errors->first($name);


### PR DESCRIPTION
When using input fields with named indices, the regexp in the getErrors function is very limited. For e.g. it fails to parse "field[0][my_field]". 
