### PR TITLE
Fix for #122. getError also now supports fields with underscores

### DIFF
--- a/src/Former/Former.php
+++ b/src/Former/Former.php
@@ -241,6 +241,8 @@ class Former
    */
   public function getPost($name, $fallback = null)
   {
+    $name = str_replace(array('[', ']'), array('.', ''), $name); 
+
     $oldValue = $this->app['request']->old($name, $fallback);
 
     return $this->app['request']->get($name, $oldValue, true);
@@ -430,7 +432,7 @@ class Former
 
     // Get name and translate array notation
     if(!$name) $name = $this->field->getName();
-    $name = preg_replace('/\[([a-z]+)\]/', '.$1', $name);
+    $name = str_replace(array('[', ']'), array('.', ''), $name);
 
     if ($this->errors) {
       return $this->errors->first($name);


### PR DESCRIPTION
HI Guys

I couldn't get former to load the correct relationships and values. I traced the code and opened this issue https://github.com/laravel/framework/pull/1802#issuecomment-20357787 for the Laravel base framework.

Taylorotwell made a great suggestion and I have implemented his suggestion in the former code. I also updated line 433 because that regular expression did not allow for form values to be repopulated if they had underscores.

With this update it is now possible to set up forms like this

```
{{ Former::populate($order) }}

{{ Former::select('order_status', 'Order Status')
                    ->options(array(
                        'Order Received' => 'Order Received', 
                        'Processing' => 'Processing',
                        'Ready for Collection' => 'Ready for Collection',
                        'Shipped' => 'Shipped',
                        )) }}

{{ Former::text('user[address][address_line1]', 'Address') }}
{{ Former::text('user[address][address_line2]', '') }}
{{ Former::text('user[address][suburb]', 'Suburb') }}
{{ Former::text('user[address][city]', 'City') }}

```

In this example a model "Order" is passed to Former::populate. Order "belongsTo" model User, and User hasOne Adddress (ie, there are multiple deep nested relationships). 

I use this code in production and repopulation on validation errors works 100%. This should fix #122.

Also note that I used "array notation" and not dot notation. The reason for this is simple - it allows you to use Eloquent's "fill()" method when saving. It is a life saver when working with large tables with many columns. 

Hope this helps
