### PR TITLE
Replace '_' with space in field name when translate.

### DIFF
--- a/src/Former/Helpers.php
+++ b/src/Former/Helpers.php
@@ -59,7 +59,7 @@ class Helpers
 
     // If no fallback, use the key
     if (!$fallback) {
-      $fallback = $key;
+      $fallback = str_replace('_', ' ', $key);
     }
 
     // Assure we don't already have a Lang object


### PR DESCRIPTION
When translation and fallback not available, it uses field name for translated text. I changed it to replace '_' with space so that 'customer_name' field will be translated to 'Customer name' without having to define in language file.
