### PR TITLE
[Agnostic] Switch encode() to allow double encoding

### DIFF
--- a/src/Former/Helpers.php
+++ b/src/Former/Helpers.php
@@ -35,7 +35,7 @@ class Helpers
    */
   public static function encode($value)
   {
-    return htmlentities($value, ENT_QUOTES, 'UTF-8', false);
+    return htmlentities($value, ENT_QUOTES, 'UTF-8', true);
   }
 
   ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The use case is when you are storing HTML in a database and your text has some markup (like <hr/>) but also some entities (&amp;).  I want to render the HTML exactly how it is in the database but currently the entities get decoded when they get rendered into a Former form field. So, even if I make no changes to the text in my admin form, the text does change (all entities get decoded).
