### PR TITLE
Ensure app[former.field] is bound before using

### DIFF
--- a/src/Former/Former.php
+++ b/src/Former/Former.php
@@ -376,7 +376,7 @@ class Former
   public function getErrors($name = null)
   {
     // Get name and translate array notation
-    if (!$name and $this->app['former.field']) {
+    if (!$name and $this->app->bound('former.field') and $this->app['former.field']) {
       $name = $this->app['former.field']->getName();
     }
 


### PR DESCRIPTION
If a group is manually opened before any field has been used, an exception is thrown on Former::getErrors() line 380. PR fixes.

It seems like GroupTest::testCanOpenGroupManually() should have caught this; not sure what other test to write to verify this doesn't happen again.
