### PR TITLE
Strip off '[]' when auto generate label from field name of multi-select field

### DIFF
--- a/src/Former/Traits/Field.php
+++ b/src/Former/Traits/Field.php
@@ -360,7 +360,7 @@ abstract class Field extends FormerObject implements FieldInterface
     if ($label and is_null($name)) {
       $name = String::slug($label);
     } elseif (is_null($label) and $name) {
-      $label = $name;
+      $label = preg_replace('/\[\]$/', '', $name);
     }
 
     // Save values

--- a/tests/Traits/FieldTest.php
+++ b/tests/Traits/FieldTest.php
@@ -158,4 +158,22 @@ class FieldTest extends FormerTests
     $this->assertHTML($this->matchControlGroup(), $static);
     $this->assertHTML($field, $static);
   }
+
+  public function testAutomaticLabelsForSingleSelectField()
+  {
+    $field = $this->former->select('foo');
+
+    $matcher = '<div class="control-group"><label for="foo" class="control-label">Foo</label><div class="controls"><select id="foo" name="foo"></select></div></div>';
+
+    $this->assertEquals($matcher, $field->__toString());
+  }
+
+  public function testAutomaticLabelsForMultiSelectField()
+  {
+    $field = $this->former->select('foo[]');
+
+    $matcher = '<div class="control-group"><label for="foo[]" class="control-label">Foo</label><div class="controls"><select id="foo[]" name="foo[]"></select></div></div>';
+
+    $this->assertEquals($matcher, $field->__toString());
+  }
 }


### PR DESCRIPTION
For multi-select list box, the field name will have suffix '[]' e.g. colors[]. Currently Former will search for 'colors[]' from the language file while most of the time we only define translation for 'colors'.

I just realized the code is not robust as we should only replace the last two characters if they are '[]'.
