### PR TITLE
[L4] Checkbox checked state does not get set properly

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -33,7 +33,7 @@
   'push_checkboxes'   => false,
 
   // The value a checkbox will have in the POST array if unchecked
-  'unchecked_value'   => 0,
+  'unchecked_value'   => '0',
 
   // Required fields
   ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The checkbox state was not set correctly, they were always checked. (I am using L4 with MySQL, in my DB unchecked value is 0 with boolean type).

Changing the configuration unchecked_value to '0' from 0 and it sorted out my problem. Looks like there are some previous problems with checboxes, maybe it will relate with some other problems eventhough the solution is simple. 
