### PR TITLE
[L4] Bootstrap 3 inline actions block needs 'form-group' class

### DIFF
--- a/src/Former/Framework/TwitterBootstrap3.php
+++ b/src/Former/Framework/TwitterBootstrap3.php
@@ -265,7 +265,7 @@ class TwitterBootstrap3 extends Framework implements FrameworkInterface
    */
   public function getActionClasses()
   {
-    if ($this->app['former.form']->isOfType('horizontal')) {
+    if ($this->app['former.form']->isOfType('horizontal') || $this->app['former.form']->isOfType('inline')) {
       return 'form-group';
     } else {
       return null;

--- a/tests/Framework/TwitterBootstrap3Test.php
+++ b/tests/Framework/TwitterBootstrap3Test.php
@@ -175,4 +175,17 @@ class TwitterBootstrap3Test extends FormerTests
     $this->former->close();
   }
 
+  public function testAddFormControlClassToInlineActionsBlock()
+  {
+    $this->former->open_inline();
+    $buttons = $this->former->actions()->submit('Foo')->__toString();
+    $match = '<div class="form-group">'.
+               '<input class="btn" type="submit" value="Foo">'.
+             '</div>';
+
+    $this->assertEquals($match, $buttons);
+
+    $this->former->close();
+  }
+
 }


### PR DESCRIPTION
According to [the Bootstrap 3 documentation](http://getbootstrap.com/css/#forms-inline) the actions in an inline form should either not be wrapped by a div or else the div block containing the actions needs to have the 'form-group' class.
You can see this bug in this [jsfiddle](http://jsfiddle.net/YNWaH/embedded/result/).
This bug should obviously appear in all environments, however I only tested it in L4.

I already fixed this bug and will do a pull request right after posting this issue.
I also included a test to check if this bug persists.

A workaround to this until my pull request gets accepted is to use the following:

```
Former::actions()->submit('Foo')->class('form-group');
```

This is my first issue report and pull request on github, so please be gentle with me.
I hope I did everything right.

Yours sincerely

Sascha Vincent Kurowski
