### PR TITLE
Ensure grouped checkboxes get error class and message

### DIFF
--- a/src/Former/Former.php
+++ b/src/Former/Former.php
@@ -381,7 +381,7 @@ class Former
     }
 
     if ($this->errors and $name) {
-      $name = str_replace(array('[', ']'), array('.', ''), $name);
+      $name = str_replace(array('[]', '[', ']'), array('', '.', ''), $name);
 
       return $this->errors->first($name);
     }

--- a/tests/Fields/CheckboxTest.php
+++ b/tests/Fields/CheckboxTest.php
@@ -313,6 +313,31 @@ class CheckboxTest extends FormerTests
       '</label>', $checkboxes);
   }
 
+  public function testCanRecognizeGroupedCheckboxesValidationErrors()
+  {
+    $this->session = $this->mockSession(array('foo' => 'bar', 'bar' => 'baz'));
+    $this->former->withErrors();
+
+    $auto =  $this->former->checkboxes('foo[]', '')->checkboxes('Value 01', 'Value 02')->__toString();
+    $chain = $this->former->checkboxes('foo', '')->grouped()->checkboxes('Value 01', 'Value 02')->__toString();
+
+    $matcher =
+      '<div class="control-group error">'.
+      '<div class="controls">'.
+      '<label for="foo_0" class="checkbox">'.
+      '<input id="foo_0" type="checkbox" name="foo[]" value="0">Value 01'.
+      '</label>'.
+      '<label for="foo_1" class="checkbox">'.
+      '<input id="foo_1" type="checkbox" name="foo[]" value="1">Value 02'.
+      '</label>'.
+      '<span class="help-inline">bar</span>'.
+      '</div>'.
+      '</div>';
+
+    $this->assertEquals($matcher, $auto);
+    $this->assertEquals($matcher, $chain);
+  }
+
   public function testCanCustomizeTheUncheckedValue()
   {
     $this->config = $this->mockConfig(true, 'unchecked', true);


### PR DESCRIPTION
This is a fix and tests for error messages on grouped checkboxes mentioned in #220
