### PR TITLE
Let Populator::get('foo[4]') work for array items

### DIFF
--- a/src/Former/Populator.php
+++ b/src/Former/Populator.php
@@ -36,7 +36,7 @@ class Populator extends Collection
   public function get($field, $fallback = null)
   {
     // Plain array
-    if (is_array($this->items)) {
+    if (is_array($this->items) && !str_contains($field,'[')) {
       return parent::get($field, $fallback);
     }
 


### PR DESCRIPTION
This simple change makes `Populator::get('foo[3]')` not throw an error if $this->items is an array (such as with `Former::populate(array('foo' => array('3' => true)))`).

I didn't add a test, since it would conflict with the tests in #223; I'll add additional tests after one or both of these issues are merged.
