### PR TITLE
Fix issue with populator on Laravel 4.1-dev

### DIFF
--- a/src/Former/FormerServiceProvider.php
+++ b/src/Former/FormerServiceProvider.php
@@ -188,11 +188,11 @@ class FormerServiceProvider extends ServiceProvider
       return new $frameworkClass($app);
     });
 
-    $app->singleton('former.populator', function ($app) {
+    $app->bindShared('former.populator', function ($app) {
       return new Populator;
     });
 
-    $app->singleton('former', function ($app) {
+    $app->bindShared('former', function ($app) {
       return new Former($app);
     });
 


### PR DESCRIPTION
When the populator is registered in the app with the singleton method, it does not populate correctly the fields of a form.
I don't know why but even if it should be a singleton, each call to $app['former.populator'] would return a new empty populator. The problem disappears when using the bindShared method.

I believe it will also happens on the develop branch as the service provider is equivalent.
