### PR TITLE
Fix validation for array elements (multiselect, radios, checkboxes) using the foo[] naming structure

### DIFF
--- a/src/Former/Former.php
+++ b/src/Former/Former.php
@@ -225,6 +225,7 @@ class Former
   public function getPost($name, $fallback = null)
   {
     $name = str_replace(array('[', ']'), array('.', ''), $name);
+    $name = trim($name, '.');
     $oldValue = $this->app['request']->old($name, $fallback);
 
     return $this->app['request']->get($name, $oldValue, true);
@@ -382,6 +383,7 @@ class Former
 
     if ($this->errors and $name) {
       $name = str_replace(array('[', ']'), array('.', ''), $name);
+      $name = trim($name, '.');
 
       return $this->errors->first($name);
     }


### PR DESCRIPTION
Unfortunately with the current tests setup I couldn't get this to be replicated, but it doesn't break existing tests. Essentially, if you have a multiselect, radio group, etc. which relys on a foo[] naming structure,the error state doesn't get applied correctly.

This is because it's searching for "foo." instead of "foo", since it converts "foo[]" to "foo.", even though that is incorrect.

If someone can write some tests for this, it'd be great. But I can't seem to get it to call these functions in a test.

This should fix the following issues: #179, #192 (I believe)
