### PR TITLE
While populating, if the model implements toArray() use that rather than a cast

### DIFF
--- a/src/Former/Populator.php
+++ b/src/Former/Populator.php
@@ -146,7 +146,11 @@ class Populator extends Collection
       return $model->getAttribute($attribute);
     }
 
-    $model = (array) $model;
+    if (method_exists($model, 'toArray')) {
+      $model = $model->toArray();
+    } else {
+      $model = (array) $model;
+    }
     if (array_key_exists($attribute, $model)) {
       return $model[$attribute];
     }

--- a/tests/Dummy/DummyToArray.php
+++ b/tests/Dummy/DummyToArray.php
@@ -1,0 +1,16 @@
+<?php
+
+class DummyToArray
+{
+  protected $values;
+
+  public function __construct(array $values = array())
+  {
+    $this->values = $values;
+  }
+
+  public function toArray()
+  {
+    return $this->values;
+  }
+}

--- a/tests/PopulatorTest.php
+++ b/tests/PopulatorTest.php
@@ -96,4 +96,14 @@ class PopulatorTest extends FormerTests
 
     $this->assertEquals('two', $populator->get('foo[1]'));
   }
+
+  public function testCanCastModelToArray()
+  {
+    $model = new DummyToArray(array(
+      'user' => new DummyToArray(array('name' => 'foo'))
+    ));
+    $populator = new Populator($model);
+
+    $this->assertEquals('foo', $populator->get('user.name'));
+  }
 }


### PR DESCRIPTION
I'm working with some non-Laravel models atm, and it would be nice to use them with Former's populator. The properties are protected, so when casting to an array you get asterisks prepended to the keys (bah):

```
class Obj { protected $field; public function setField($val) { $this->field = $val; return $this; } }
var_dump((array) (new Obj)->setField(123));

array(1) { '\0*\0field' => int(123) }
```

Given that (anecdotally) the method most models use to cast to array is called `toArray`, this checks to see if the method exists first rather than casting.  Potentially it could check for `to_array` as well? Thoughts?
