### PR TITLE
Translate fields using square brackets like those with periods

### DIFF
--- a/src/Former/Helpers.php
+++ b/src/Former/Helpers.php
@@ -73,6 +73,11 @@ class Helpers
     }
     $translateFrom .= $key;
 
+    // Convert a[b[c]] to a.b.c for nested translations [a => [b => 'B!']]
+    if (strpos($translateFrom, ']') !== false) {
+      $translateFrom = str_replace(array(']', '['), array('', '.'), $translateFrom);
+    }
+
     // Search for the key itself
     if (static::$app['translator']->has($key)) {
       $translation = static::$app['translator']->get($key);

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -29,4 +29,15 @@ class HelpersTest extends FormerTests
 
     $this->assertEquals('field', Former\Helpers::translate('field'));
   }
+
+  public function testNestedTranslationFieldNames()
+  {
+    $matcher = $this->matchLabel('City', 'address.city');
+    $input = $this->former->text('address.city')->__toString();
+    $this->assertHTML($matcher, $input);
+
+    $matcher = $this->matchLabel('City', 'address[city]');
+    $input = $this->former->text('address[city]')->__toString();
+    $this->assertHTML($matcher, $input);
+  }
 }

--- a/tests/TestCases/ContainerTestCase.php
+++ b/tests/TestCases/ContainerTestCase.php
@@ -254,8 +254,11 @@ abstract class ContainerTestCase extends PHPUnit_Framework_TestCase
         ->shouldReceive('get')->with('pagination.next')->andReturn('Next')
         ->shouldReceive('get')->with('pagination')->andReturn(array('previous' => 'Previous', 'next' => 'Next'))
         ->shouldReceive('get')->with('validation.attributes.field_name_with_underscore')->andReturn(false)
+        ->shouldReceive('get')->with('validation.attributes.address.city')->andReturn('City')
         ->shouldReceive('get')->withAnyArgs()->andReturnUsing(function ($key) { return $key; })
         ->shouldReceive('has')->with('field_name_with_underscore')->andReturn(false)
+        ->shouldReceive('has')->with('address.city')->andReturn(false)
+        ->shouldReceive('has')->with('address[city]')->andReturn(false)
         ->shouldReceive('has')->withAnyArgs()->andReturn(true);
     });
   }


### PR DESCRIPTION
See #267

For example, the following inputs will both be translated with the same (Laravel) translation rule:

```
Former::text('address[city]')
Former::text('address.city')

[ 'validation' => [
    'attributes' => [
      'address' => [
        'city' => 'City'
      ]
    ]
  ]
]
```
