### PR TITLE
BUGFIX [AGNOSTIC] fixing inline form validation display for Zurb

### DIFF
--- a/src/Former/Framework/ZurbFoundation.php
+++ b/src/Former/Framework/ZurbFoundation.php
@@ -156,7 +156,7 @@ class ZurbFoundation extends Framework implements FrameworkInterface
 
   public function createHelp($text, $attributes = array())
   {
-    return Element::create('small', $text, $attributes);
+    return Element::create('span', $text, $attributes);
   }
 
   /**

--- a/src/Former/Framework/ZurbFoundation4.php
+++ b/src/Former/Framework/ZurbFoundation4.php
@@ -158,7 +158,7 @@ class ZurbFoundation4 extends Framework implements FrameworkInterface
 
   public function createHelp($text, $attributes = '')
   {
-    return Element::create('small', $text, $attributes);
+    return Element::create('span', $text, $attributes);
   }
 
   /**


### PR DESCRIPTION
This changes the inline help text for form validation from

```
    <small>help text</small>
```

to

```
    <span>help text</span>
```

This allows attributes to be set correctly without working around the `<small>` tag, like in the TwitterBootstrap adapter, for example:

```
Former::text('somefield')
        ->label('Some Field')
        ->state('error')->help('Some field is required.', [ 'class' => 'alert-box warning radius'] )
```

I didn't add a test - let me know if you need one for this.
