### PR TITLE
Fix grouped checkbox repopulating from POST and the Populator.

### DIFF
--- a/src/Former/Form/Fields/Checkbox.php
+++ b/src/Former/Form/Fields/Checkbox.php
@@ -24,6 +24,10 @@ class Checkbox extends Checkable
    */
   public function checkboxes()
   {
+    if ($this->isGrouped()) {
+      // Remove any possible items added by the Populator.
+      $this->items = array();
+    }
     $this->items(func_get_args());
 
     return $this;

--- a/src/Former/Traits/Checkable.php
+++ b/src/Former/Traits/Checkable.php
@@ -77,6 +77,11 @@ abstract class Checkable extends Field
    */
   public function __construct(Container $app, $type, $name, $label, $value, $attributes)
   {
+    // Unify auto and chained methods of grouping checkboxes
+    if (ends_with($name,'[]')) {
+      $name = substr($name, 0, -2);
+      $this->grouped();
+    }
     parent::__construct($app, $type, $name, $label, $value, $attributes);
 
     if (is_array($this->value)) {
@@ -233,6 +238,7 @@ abstract class Checkable extends Field
   {
     // If passing an array
     if (sizeof($_items) == 1 and
+       isset($_items[0]) and
        is_array($_items[0])) {
          $_items = $_items[0];
     }
@@ -275,6 +281,7 @@ abstract class Checkable extends Field
       $item = array(
         'name' => $name,
         'label' => Helpers::translate($label),
+        'count' => $count,
       );
       if (isset($attributes)) {
         $item['attributes'] = $attributes;
@@ -319,7 +326,7 @@ abstract class Checkable extends Field
 
     // Create field
     $field = Input::create($this->checkable, $name, $value, $attributes);
-    if ($this->isChecked($name, $value)) {
+    if ($this->isChecked($item, $value)) {
       $field->checked('checked');
     }
 
@@ -388,9 +395,12 @@ abstract class Checkable extends Field
    *
    * @return boolean Checked or not
    */
-  protected function isChecked($name = null, $value = null)
+  protected function isChecked($item = null, $value = null)
   {
-    if (!$name) {
+    if (isset($item['name'])) {
+      $name = $item['name'];
+    }
+    if (empty($name)) {
       $name = $this->name;
     }
 
@@ -407,8 +417,24 @@ abstract class Checkable extends Field
     }
 
     // Check the values and POST array
-    $post   = $this->app['former']->getPost($name);
-    $static = $this->app['former']->getValue($name);
+    if ($this->isGrouped()) {
+      $groupIndex = self::getGroupIndexFromItem($item);
+
+      // Search using the bare name, not the individual item name
+      $post   = $this->app['former']->getPost($this->name);
+      $static = $this->app['former']->getValue($this->name);
+
+      if (isset($post[$groupIndex])) {
+        $post = $post[$groupIndex];
+      }
+      if (isset($static[$groupIndex])) {
+        $static = $static[$groupIndex];
+      }
+
+    } else {
+      $post   = $this->app['former']->getPost($name);
+      $static = $this->app['former']->getValue($name);
+    }
 
     if (!is_null($post) and $post !== $this->app['former']->getOption('unchecked_value')) {
       $isChecked = ($post == $value);
@@ -441,5 +467,18 @@ abstract class Checkable extends Field
     return
       $this->grouped == true or
       strpos($this->name, '[]') !== false;
+  }
+
+  /**
+   * @param array $item The item array, containing at least name and count keys.
+   * @return mixed The group index. (e.g. returns bar if the item name is foo[bar], or the item count for foo[])
+   */
+  public static function getGroupIndexFromItem($item)
+  {
+    $groupIndex = preg_replace('/^.*?\[(.*)\]$/', '$1', $item['name']);
+    if (empty($groupIndex) or $groupIndex == $item['name']) {
+      return $item['count'];
+    }
+    return $groupIndex;
   }
 }

--- a/tests/Fields/CheckboxTest.php
+++ b/tests/Fields/CheckboxTest.php
@@ -322,21 +322,120 @@ class CheckboxTest extends FormerTests
       '</label>', $auto);
   }
 
+
+  public function testCanCustomizeGroupedCheckboxes()
+  {
+    $this->former->framework('Nude');
+
+    $checkboxes = array(
+      'Value 01' => array(
+        'id' => 'value[foo_id]',
+        'name' => 'value[foo_name]',
+        'value' => 'foo_value',
+      ),
+      'Value 02' => array(
+        'id' => 'value[bar_id]',
+        'name' => 'value[bar_name]',
+        'value' => 'bar_value',
+      ),
+    );
+
+    $this->former->populate(array('value' => array('foo_name' => 'foo_value')));
+    $auto =  $this->former->checkboxes('value[]', '')->checkboxes($checkboxes)->__toString();
+    $chain = $this->former->checkboxes('value', '')->grouped()->checkboxes($checkboxes)->__toString();
+
+    $this->assertEquals($chain, $auto);
+    $this->assertEquals(
+      '<label for="value[foo_id]" class="checkbox">'.
+        '<input id="value[foo_id]" value="foo_value" type="checkbox" name="value[foo_name]" checked="checked">Value 01'.
+      '</label>'.
+      '<label for="value[bar_id]" class="checkbox">'.
+        '<input id="value[bar_id]" value="bar_value" type="checkbox" name="value[bar_name]">Value 02'.
+      '</label>', $auto);
+  }
+
   public function testCanRepopulateGroupedCheckboxes()
   {
-    $this->markTestSkipped('This is failing you guys');
-
     $this->former->framework('Nude');
-    $this->former->populate(array('foo' => array('foo_0')));
-    $checkboxes = $this->former->checkboxes('foo', '')->grouped()->checkboxes('Value 01', 'Value 02')->__toString();
+    $this->former->populate(array('foo' => array(0 => 0, 1 => 1)));
 
-    $this->assertEquals(
+    $chain = $this->former->checkboxes('foo', '')->grouped()->checkboxes('Value 01', 'Value 02', 'Value 03')->__toString();
+    $auto = $this->former->checkboxes('foo[]', '')->checkboxes('Value 01', 'Value 02', 'Value 03')->__toString();
+
+    $matcher =
       '<label for="foo_0" class="checkbox">'.
-        '<input id="foo_0" checked="checked" type="checkbox" name="foo[]" value="1">Value 01'.
+        '<input id="foo_0" type="checkbox" name="foo[]" checked="checked" value="0">Value 01'.
       '</label>'.
       '<label for="foo_1" class="checkbox">'.
-        '<input id="foo_1" type="checkbox" name="foo[]" value="1">Value 02'.
-      '</label>', $checkboxes);
+        '<input id="foo_1" type="checkbox" name="foo[]" checked="checked" value="1">Value 02'.
+      '</label>'.
+      '<label for="foo_2" class="checkbox">'.
+        '<input id="foo_2" type="checkbox" name="foo[]" value="2">Value 03'.
+      '</label>';
+
+    $this->assertEquals($matcher, $chain);
+    $this->assertEquals($matcher, $auto);
+  }
+
+  public function testCanRepopulateGroupedCheckboxesFromPost()
+  {
+    $this->former->framework('Nude');
+
+    $this->request->shouldReceive('input')->with('_token', '', true)->andReturn('');
+    $this->request->shouldReceive('input')->with('foo', '', true)->andReturn(
+      array(0 => 0, 1 => 1)
+    );
+
+    $chain = $this->former->checkboxes('foo', '')->grouped()->checkboxes('Value 01', 'Value 02', 'Value 03')->__toString();
+    $auto = $this->former->checkboxes('foo[]', '')->checkboxes('Value 01', 'Value 02', 'Value 03')->__toString();
+
+    $matcher =
+      '<label for="foo_0" class="checkbox">'.
+        '<input id="foo_0" type="checkbox" name="foo[]" checked="checked" value="0">Value 01'.
+      '</label>'.
+      '<label for="foo_1" class="checkbox">'.
+        '<input id="foo_1" type="checkbox" name="foo[]" checked="checked" value="1">Value 02'.
+      '</label>'.
+      '<label for="foo_2" class="checkbox">'.
+        '<input id="foo_2" type="checkbox" name="foo[]" value="2">Value 03'.
+      '</label>';
+
+    $this->assertEquals($matcher, $chain);
+    $this->assertEquals($matcher, $auto);
+  }
+
+  public function testCanRepopulateCustomizedGroupedCheckboxesFromPost()
+  {
+    $this->former->framework('Nude');
+
+    $checkboxes = array(
+      'Value 01' => array(
+        'id' => 'value[foo_id]',
+        'name' => 'value[foo_name]',
+        'value' => 'foo_value',
+      ),
+      'Value 02' => array(
+        'id' => 'value[bar_id]',
+        'name' => 'value[bar_name]',
+        'value' => 'bar_value',
+      ),
+    );
+
+    $this->request->shouldReceive('input')->with('_token', '', true)->andReturn('');
+    $this->request->shouldReceive('input')->with('value', '', true)->andReturn(
+      array('foo_name' => 'foo_value')
+    );
+    $auto =  $this->former->checkboxes('value[]', '')->checkboxes($checkboxes)->__toString();
+    $chain = $this->former->checkboxes('value', '')->grouped()->checkboxes($checkboxes)->__toString();
+
+    $this->assertEquals($chain, $auto);
+    $this->assertEquals(
+      '<label for="value[foo_id]" class="checkbox">'.
+        '<input id="value[foo_id]" value="foo_value" type="checkbox" name="value[foo_name]" checked="checked">Value 01'.
+      '</label>'.
+      '<label for="value[bar_id]" class="checkbox">'.
+        '<input id="value[bar_id]" value="bar_value" type="checkbox" name="value[bar_name]">Value 02'.
+      '</label>', $auto);
   }
 
   public function testCanCustomizeTheUncheckedValue()


### PR DESCRIPTION
This is my second attempt at #223 / #220 / #35, this time with more care not to break existing code.

This PR fixes repopulating grouped checkboxes from POST, and also enables the following repopulate syntax:

``` php
// Numerically indexed checkboxes -- "Checkbox 1" will be checked:
Former::populate(array('foo' => array(0 /* index */=> 0 /* value */)));
Former::checkboxes('foo[]')->checkboxes('Checkbox 1', 'Checkbox 2');

// string indexed checkboxes -- "Checkbox 1" will be checked:
Former::populate(array('foo' => array('name1' => 'value1')));
Former::checkboxes('foo[]')->checkboxes(
  'Checkbox 1' => array('name' => 'foo[name1]', 'value' => 'value1'),
  'Checkbox 2' => array('name' => 'foo[name2]', 'value' => 'value2'),
);

// Grouping using the "chain" syntax is also identically supported:
Former::checkboxes('foo')->grouped()->checkboxes('Checkbox 1', 'Checkbox 2');
```

Two things I did not do in this PR, that I will open separate pull requests for:
- In my opinion, the values for grouped checkboxes should be 1 by default, not 0/1/2/etc.
- It would be handy to be able to populate using IDs instead of names/index, e.g. `Former::populate(array('foo_0' => 1))`

I didn't combine these since I'm not sure what caused #223 to break existing code.

Note that Travis tests won't pass on this until #301 lands.
