### PR TITLE
Fix for issue #299.

### DIFF
--- a/src/Former/Former.php
+++ b/src/Former/Former.php
@@ -417,6 +417,8 @@ class Former
     // Get name and translate array notation
     if (!$name and $this->app['former.field']) {
       $name = $this->app['former.field']->getName();
+      // Always return empty string for anonymous fields (i.e. fields with no name/id)
+      if (!$name) return '';
     }
 
     if ($this->errors and $name) {


### PR DESCRIPTION
This fixes issue #299 so that anonymous fields (i.e. fields with no name/id) never get an error messages. Without this fix, anonymous fields show all error messages.
