### PR TITLE
Fix and test multiple select repopulation.

### DIFF
--- a/src/Former/Form/Fields/Select.php
+++ b/src/Former/Form/Fields/Select.php
@@ -62,8 +62,8 @@ class Select extends Field
 
     parent::__construct($app, $type, $name, $label, $selected, $attributes);
 
-    // Multiple models population
-    if (is_array($this->value) and !empty($this->value) and is_string($this->value[key($this->value)])) {
+    // Nested models population
+    if (str_contains($this->name, '.') and is_array($this->value) and !empty($this->value) and is_string($this->value[key($this->value)])) {
       $this->fromQuery($this->value);
       $this->value = $selected ?: null;
     }

--- a/tests/Fields/SelectTest.php
+++ b/tests/Fields/SelectTest.php
@@ -267,6 +267,28 @@ class SelectTest extends FormerTests
     $this->assertEquals($matcher, $select);
   }
 
+  public function testCanRepopulateMultipleSelectsFromPost()
+  {
+    $options = array(
+      'foo' => 'foo_name',
+      'bar' => 'bar_name',
+      'baz' => 'baz_name',
+    );
+
+    $this->request->shouldReceive('input')->with('_token', '', true)->andReturn('foobar');
+    $this->request->shouldReceive('input')->with('test', '', true)->andReturn(array('foo', 'bar'));
+
+    $select = $this->former->multiselect('test')->options($options)->render();
+    $matcher =
+      '<select id="test" multiple="true" name="test[]">'.
+        '<option value="foo" selected="selected">foo_name</option>'.
+        '<option value="bar" selected="selected">bar_name</option>'.
+        '<option value="baz">baz_name</option>'.
+      '</select>';
+
+    $this->assertEquals($matcher, $select);
+  }
+
   public function testCanCreateRangeSelects()
   {
     $select = $this->former->select('foo')->range(1, 10);
@@ -347,7 +369,7 @@ class SelectTest extends FormerTests
     $this->assertContains($matcher, $select);
   }
 
-  public function testCanRepopulateArrayNotation()
+  public function testCanRepopulateFromPostArrayNotation()
   {
     $options = array('foo', 'bar');
     $this->request->shouldReceive('input')->with('_token', '', true)->andReturn('foobar');
@@ -355,6 +377,22 @@ class SelectTest extends FormerTests
 
     $select  = $this->former->select('foo[]')->options($options);
     $matcher = '<select id="foo[]" name="foo[]"><option value="0" selected="selected">foo</option><option value="1" selected="selected">bar</option></select>';
+
+    $this->assertEquals($matcher, $select->render());
+  }
+
+  public function testCanRepopulateFromPostStringIndexedArrayNotation()
+  {
+    $options = array('foo' => 'foo_name', 'bar' => 'bar_name');
+    $this->request->shouldReceive('input')->with('_token', '', true)->andReturn('foobar');
+    $this->request->shouldReceive('input')->with('foo', '', true)->andReturn(array('foo', 'bar'));
+
+    $select  = $this->former->select('foo[]')->options($options);
+    $matcher =
+      '<select id="foo[]" name="foo[]">'.
+        '<option value="foo" selected="selected">foo_name</option>'.
+        '<option value="bar" selected="selected">bar_name</option>'.
+      '</select>';
 
     $this->assertEquals($matcher, $select->render());
   }


### PR DESCRIPTION
This PR fixes #202, #99 and possibly #221 and #273.

It ends up that the Nested models population code in the Select constructor was breaking multiselect repopulation for options with string values.

I added additional test cases for options with string values.

I'm hopeful that the `str_contains($this->name, '.')` check I added is acceptable, as this was by far the cleanest fix I found. Can anyone verify that the "Multiple models population" code in Select::__construct() should only be needed if the name contains a dot?
