### PR TITLE
Fixed config namespace missing in getOption

### DIFF
--- a/src/Former/Former.php
+++ b/src/Former/Former.php
@@ -356,7 +356,7 @@ class Former
    */
   public function getOption($option, $default = null)
   {
-    return $this->app['config']->get('former::'.$option, $default);
+    return $this->app['config']->get('former::config.'.$option, $default);
   }
 
   /**


### PR DESCRIPTION
After some composer updating and moving former package as my package project dependency, It start to show problem. Auto translation not working, fatal error on some task which require value fetch from config file.
