### PR TITLE
Added optional $step param to range method

### DIFF
--- a/src/Former/Form/Fields/Select.php
+++ b/src/Former/Form/Fields/Select.php
@@ -197,8 +197,9 @@ class Select extends Field
    *
    * @param  integer $from
    * @param  integer $to
+   * @param  integer $step
    */
-  public function range($from, $to)
+  public function range($from, $to, $step = 1)
   {
     $range = range($from, $to);
     $this->options($range, null, true);


### PR DESCRIPTION
The $step param defaults to 1 but allows for use of PHP's optional third param which increments the array by the specified integer.

```
range(15, 60, 15);  //15, 30, 45, 60
```
