### PR TITLE
Added optional $step param to range method (function)

### DIFF
--- a/src/Former/Form/Fields/Select.php
+++ b/src/Former/Form/Fields/Select.php
@@ -201,7 +201,7 @@ class Select extends Field
    */
   public function range($from, $to, $step = 1)
   {
-    $range = range($from, $to);
+    $range = range($from, $to, $step);
     $this->options($range, null, true);
 
     return $this;


### PR DESCRIPTION
The $step param defaults to 1 but allows for use of PHP's optional third param which increments the array by the specified integer.

```
range(15, 60, 15);  //15, 30, 45, 60
```

Note: on my last pull request I didn't actually add the $step param to the range() function.  It is included here now.
