### PR TITLE
Block Help for Bootstrap3

### DIFF
--- a/src/Former/Form/Group.php
+++ b/src/Former/Form/Group.php
@@ -290,7 +290,7 @@ class Group extends Tag
   public function blockHelp($help, $attributes = array())
   {
     // Reserved method
-    if ($this->app['former.framework']->isnt('TwitterBootstrap')) {
+    if ($this->app['former.framework']->isnt('TwitterBootstrap') && $this->app['former.framework']->isnt('TwitterBootstrap3')) {
       throw new BadMethodCallException('This method is only available on the Bootstrap framework');
     }
 

--- a/src/Former/Framework/TwitterBootstrap3.php
+++ b/src/Former/Framework/TwitterBootstrap3.php
@@ -307,6 +307,19 @@ class TwitterBootstrap3 extends Framework implements FrameworkInterface
   }
 
   /**
+   * Render an help text
+   *
+   * @param string $text
+   * @param array  $attributes
+   *
+   * @return string
+   */
+  public function createBlockHelp($text, $attributes = array())
+  {
+    return Element::create('p', $text, $attributes)->addClass('help-block');
+  }
+
+  /**
    * Render a disabled field
    *
    * @param Field $field


### PR DESCRIPTION
Block help shouldn't be limited to bootstrap two, added support for Bootstrap3
