### PR TITLE
Add additional tests for radios, cleanup radio tests a bit.

### DIFF
--- a/tests/Fields/RadioTest.php
+++ b/tests/Fields/RadioTest.php
@@ -139,10 +139,10 @@ class RadioTest extends FormerTests
 
   public function testMultipleCustom()
   {
-    $radios = $this->former->radios('foo')->radios($this->checkables)->__toString();
+    $radios = $this->former->radios('foo')->radios($this->radioCheckables)->__toString();
     $matcher = $this->controlGroup(
     '<label for="foo" class="radio">'.
-      '<input data-foo="bar" value="bar" id="foo" type="radio" name="foo">'.
+      '<input data-foo="bar" value="foo" id="foo" type="radio" name="foo">'.
       'Foo'.
     '</label>'.
     '<label for="bar" class="radio">'.
@@ -155,14 +155,14 @@ class RadioTest extends FormerTests
 
   public function testMultipleCustomNoName()
   {
-    $checkables = $this->checkables;
+    $checkables = $this->radioCheckables;
     unset($checkables['Foo']['name']);
     unset($checkables['Bar']['name']);
 
     $radios = $this->former->radios('foo')->radios($checkables)->__toString();
     $matcher = $this->controlGroup(
     '<label for="foo" class="radio">'.
-      '<input data-foo="bar" value="bar" id="foo" type="radio" name="foo">'.
+      '<input data-foo="bar" value="foo" id="foo" type="radio" name="foo">'.
       'Foo'.
     '</label>'.
     '<label for="bar" class="radio">'.
@@ -189,10 +189,42 @@ class RadioTest extends FormerTests
     $this->assertEquals($matcher, $radios);
   }
 
+  public function testCheckOneInSeveralCustom()
+  {
+    $radios = $this->former->radios('foo')->radios($this->radioCheckables)->check('foo')->__toString();
+    $matcher = $this->controlGroup(
+      '<label for="foo" class="radio">'.
+      '<input data-foo="bar" value="foo" id="foo" type="radio" name="foo" checked="checked">'.
+      'Foo'.
+      '</label>'.
+      '<label for="bar" class="radio">'.
+      '<input data-foo="bar" value="bar" id="bar" type="radio" name="foo">'.
+      'Bar'.
+      '</label>');
+
+    $this->assertEquals($matcher, $radios);
+  }
+
   public function testCheckMultiple()
   {
     $radios = $this->former->radios('foo')->radios('foo', 'bar')->check(array(0 => false, 1 => true))->__toString();
     $matcher = $this->controlGroup($this->matchRadio('foo', 'Foo', 0).$this->matchCheckedRadio('foo2', 'Bar', 1));
+
+    $this->assertEquals($matcher, $radios);
+  }
+
+  public function testCheckMultipleCustom()
+  {
+    $radios = $this->former->radios('foo')->radios($this->radioCheckables)->check(array('foo' => true, 'bar' => false))->__toString();
+    $matcher = $this->controlGroup(
+      '<label for="foo" class="radio">'.
+      '<input data-foo="bar" value="foo" id="foo" type="radio" name="foo" checked="checked">'.
+      'Foo'.
+      '</label>'.
+      '<label for="bar" class="radio">'.
+      '<input data-foo="bar" value="bar" id="bar" type="radio" name="foo">'.
+      'Bar'.
+      '</label>');
 
     $this->assertEquals($matcher, $radios);
   }

--- a/tests/TestCases/FormerTests.php
+++ b/tests/TestCases/FormerTests.php
@@ -61,6 +61,20 @@ abstract class FormerTests extends ContainerTestCase
     ),
   );
 
+  protected $radioCheckables = array(
+    'Foo' => array(
+      'data-foo' => 'bar',
+      'value'    => 'foo',
+      'name'     => 'foo',
+    ),
+    'Bar' => array(
+      'data-foo' => 'bar',
+      'value'    => 'bar',
+      'name'     => 'foo',
+      'id'       => 'bar',
+    ),
+  );
+
   protected $testAttributes = array(
     'class'    => 'foo',
     'data-foo' => 'bar',


### PR DESCRIPTION
I thought Former had a problem with custom-valued radios, but it ended up that my code was calling `radios()->grouped()` and I didn't notice.

During my investigation, I added these tests to Former Radios and cleaned up some other tests to prove things were working.
