### PR TITLE
repopulating fields after name change

### DIFF
--- a/src/Former/Traits/Field.php
+++ b/src/Former/Traits/Field.php
@@ -315,6 +315,8 @@ abstract class Field extends FormerObject implements FieldInterface
 
     // Also relink the label to the new name
     $this->label($name);
+    // And repolulate the field using the new name
+    $this->value = $this->repopulate();
 
     return $this;
   }


### PR DESCRIPTION
changing the name of a field will POST thats fields value under the new name on submit, but before the new name was not used in lookup of the value on form redisplay.

The repopulate method itself only repopulates if a value has not yet been set.
