### PR TITLE
Dispatch field names that use camel casing or snake casing to studly cased classes

### DIFF
--- a/src/Former/MethodDispatcher.php
+++ b/src/Former/MethodDispatcher.php
@@ -215,8 +215,11 @@ class MethodDispatcher
 	{
 		// If the field's name directly match a class, call it
 		$class = Str::singular(Str::title($method));
+		$studly_class = Str::singular(Str::studly($method));
 		foreach ($this->repositories as $repository) {
-			if (class_exists($repository.$class)) {
+			if (class_exists($repository.$studly_class)) {
+				return $repository.$studly_class;
+			} else if (class_exists($repository.$class)) {
 				return $repository.$class;
 			}
 		}

--- a/tests/MethodDispatcherTest.php
+++ b/tests/MethodDispatcherTest.php
@@ -4,6 +4,8 @@ namespace Former;
 use Former\MethodDispatcher;
 use Former\TestCases\FormerTests;
 use PHPUnit_Framework_Assert;
+use ReflectionMethod;
+use Mockery;
 
 class MethodDispatcherTest extends FormerTests
 {
@@ -16,4 +18,36 @@ class MethodDispatcherTest extends FormerTests
 		$this->assertCount(1, PHPUnit_Framework_Assert::readAttribute($dispatcher, 'repositories'));
 		$this->assertContains('A\Namespace\\', PHPUnit_Framework_Assert::readAttribute($dispatcher, 'repositories'));
 	}
+
+	/**
+	 * Test that camel-cased names like Former::fakeField get translated to
+	 * a titlecased class of A\Fakefield.  This is the original Former approach.
+	 */
+	public function testSupportsTitleCasedFields()
+	{
+		$dispatcher = new MethodDispatcher($this->app, array('A\\'));
+		$method = new ReflectionMethod($dispatcher, 'getClassFromMethod');
+		$method->setAccessible(true);
+
+		$mock = Mockery::mock('A\Fakefield');
+
+		$this->assertEquals('A\Fakefield', $method->invoke($dispatcher, 'fakefield'));
+	}
+
+	/**
+	 * Test that camel-cased names (Former::fakeField) or snake-cased names
+	 * (Fomer::fake_field) get translated to a study cased class name (FakeField)
+	 */
+	public function testSupportsCamelCasedAndSnakeCasedFields()
+	{
+		$dispatcher = new MethodDispatcher($this->app, array('A\\'));
+		$method = new ReflectionMethod($dispatcher, 'getClassFromMethod');
+		$method->setAccessible(true);
+
+		$mock = Mockery::mock('A\FakeField');
+		
+		$this->assertEquals('A\FakeField', $method->invoke($dispatcher, 'fakeField'));
+		$this->assertEquals('A\FakeField', $method->invoke($dispatcher, 'fake_field'));
+	}
+
 }


### PR DESCRIPTION
Currently, if you are on a case sensitive file system and do Former::fakeField, the matched class name will only allow Fakefield.  I think if you camel case a field name, you are intending to studly case your class name.

Because this uses the studly method, this will also translate snake cased field names.
