### PR TITLE
Zurb Foundation 5 Support

### DIFF
--- a/src/Former/Framework/ZurbFoundation5.php
+++ b/src/Former/Framework/ZurbFoundation5.php
@@ -1,0 +1,279 @@
+<?php
+namespace Former\Framework;
+
+use Former\Interfaces\FrameworkInterface;
+use Former\Traits\Field;
+use Former\Traits\Framework;
+use HtmlObject\Element;
+use HtmlObject\Input;
+use Illuminate\Container\Container;
+
+/**
+ * The Zurb Foundation 5 form framework
+ */
+class ZurbFoundation5 extends Framework implements FrameworkInterface
+{
+	/**
+	 * Form types that trigger special styling for this Framework
+	 *
+	 * @var array
+	 */
+	protected $availableTypes = array('horizontal', 'vertical');
+
+	/**
+	 * The button types available
+	 *
+	 * @var array
+	 */
+	private $buttons = array(
+		'tiny',
+		'small',
+		'medium',
+		'large',
+		'success',
+		'radius',
+		'round',
+		'disabled',
+		'prefix',
+		'postfix',
+	);
+
+	/**
+	 * The field sizes available
+	 * Zurb Foundation 5 does not apply sizes to the form element, but to the wrapper div
+	 *
+	 * @var array
+	 */
+	private $fields = array();
+
+	/**
+	 * The field states available
+	 *
+	 * @var array
+	 */
+	protected $states = array(
+		'error',
+	);
+
+	/**
+	 * Create a new ZurbFoundation instance
+	 *
+	 * @param \Illuminate\Container\Container $app
+	 */
+	public function __construct(Container $app)
+	{
+		$this->app = $app;
+		$this->setFrameworkDefaults();
+	}
+
+	////////////////////////////////////////////////////////////////////
+	/////////////////////////// FILTER ARRAYS //////////////////////////
+	////////////////////////////////////////////////////////////////////
+
+	public function filterButtonClasses($classes)
+	{
+		// Filter classes
+		$classes   = array_intersect($classes, $this->buttons);
+		$classes[] = 'button';
+
+		return $classes;
+	}
+
+	public function filterFieldClasses($classes)
+	{
+		return null;
+	}
+
+	////////////////////////////////////////////////////////////////////
+	///////////////////// EXPOSE FRAMEWORK SPECIFICS ///////////////////
+	////////////////////////////////////////////////////////////////////
+
+	protected function setFieldWidths($labelWidths)
+	{
+		$labelWidthClass = $fieldWidthClass = $fieldOffsetClass = '';
+
+		$viewports = $this->getFrameworkOption('viewports');
+
+		foreach ($labelWidths as $viewport => $columns) {
+			if ($viewport) {
+				$labelWidthClass .= $viewports[$viewport].'-'.$columns.' ';
+				$fieldWidthClass .= $viewports[$viewport].'-'.(12 - $columns).' ';
+				$fieldOffsetClass .= $viewports[$viewport].'-offset-'.$columns.' ';
+			}
+		}
+
+		$this->labelWidth  = $labelWidthClass.'columns';
+		$this->fieldWidth  = $fieldWidthClass.'columns';
+		$this->fieldOffset = $fieldOffsetClass.'columns';
+	}
+
+	////////////////////////////////////////////////////////////////////
+	///////////////////////////// ADD CLASSES //////////////////////////
+	////////////////////////////////////////////////////////////////////
+
+	public function getFieldClasses(Field $field, $classes = array())
+	{
+		if ($field->isButton()) {
+			$classes = $this->filterButtonClasses($classes);
+		} else {
+			$classes = $this->filterFieldClasses($classes);
+		}
+
+		return $this->addClassesToField($field, $classes);
+	}
+
+	public function getGroupClasses()
+	{
+		if ($this->app['former.form']->isOfType('horizontal')) {
+			return 'row';
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Add label classes
+	 *
+	 *
+	 * @return string|null An array of attributes with the label class
+	 */
+	public function getLabelClasses()
+	{
+		if ($this->app['former.form']->isOfType('horizontal')) {
+			return $this->getFrameworkOption('wrappedLabelClasses');
+		} else {
+			return null;
+		}
+	}
+
+	public function getUneditableClasses()
+	{
+		return null;
+	}
+
+	public function getFormClasses($type)
+	{
+		return null;
+	}
+
+	public function getActionClasses()
+	{
+		return null;
+	}
+
+	////////////////////////////////////////////////////////////////////
+	//////////////////////////// RENDER BLOCKS /////////////////////////
+	////////////////////////////////////////////////////////////////////
+
+	public function createHelp($text, $attributes = null)
+	{
+		if (is_null($attributes) or empty($attributes)) {
+			$attributes = $this->getFrameworkOption('error_classes');
+		}
+
+		return Element::create('small', $text, $attributes);
+	}
+
+	/**
+	 * Render a disabled field
+	 *
+	 * @param Field $field
+	 *
+	 * @return Input
+	 */
+	public function createDisabledField(Field $field)
+	{
+		$field->disabled();
+
+		return Input::create('text', $field->getName(), $field->getValue(), $field->getAttributes());
+	}
+
+	////////////////////////////////////////////////////////////////////
+	//////////////////////////// WRAP BLOCKS ///////////////////////////
+	////////////////////////////////////////////////////////////////////
+
+	/**
+	 * Wrap an item to be prepended or appended to the current field.
+	 * For Zurb we return the item and handle the wrapping in prependAppend
+	 * as wrapping is dependent on whether we're prepending or appending.
+	 *
+	 *
+	 * @return string A wrapped item
+	 */
+	public function placeAround($item)
+	{
+		return $item;
+	}
+
+	/**
+	 * Wrap a field with prepended and appended items
+	 *
+	 * @param  Field $field
+	 * @param  array $prepend
+	 * @param  array $append
+	 *
+	 * @return string A field concatented with prepended and/or appended items
+	 */
+	public function prependAppend($field, $prepend, $append)
+	{
+		$return = '<div class="row collapse">';
+
+		foreach ($prepend as $item) {
+			$return .= '<div class="large-2 small-3 columns"><span class="prefix">'.$item.'</span></div>';
+		}
+
+		$return .= '<div class="large-10 small-9 columns">'.$field->render().'</div>';
+
+		foreach ($append as $item) {
+			$return .= '<div class="large-2 small-3 columns"><span class="postfix">'.$item.'</span></div>';
+		}
+
+		$return .= '</div>';
+
+		return $return;
+	}
+
+	/**
+	 * Wraps all label contents with potential additional tags.
+	 *
+	 * @param  string $label
+	 *
+	 * @return string A wrapped label
+	 */
+	public function wrapLabel($label)
+	{
+		if ($this->app['former.form']->isOfType('horizontal')) {
+			return Element::create('div', $label)->addClass($this->labelWidth);
+		} else {
+			return $label;
+		}
+	}
+
+	/**
+	 * Wraps all field contents with potential additional tags.
+	 *
+	 * @param  Field $field
+	 *
+	 * @return Element A wrapped field
+	 */
+	public function wrapField($field)
+	{
+		if ($this->app['former.form']->isOfType('horizontal')) {
+			return Element::create('div', $field)->addClass($this->fieldWidth);
+		} else {
+			return $field;
+		}
+	}
+
+	/**
+	 * Wrap actions block with potential additional tags
+	 *
+	 * @param  Actions $actions
+	 *
+	 * @return string A wrapped actions block
+	 */
+	public function wrapActions($actions)
+	{
+		return $actions;
+	}
+}

--- a/src/config/ZurbFoundation5.php
+++ b/src/config/ZurbFoundation5.php
@@ -1,0 +1,32 @@
+<?php return array(
+
+	// Zurb Foundation 5 framework markup
+	////////////////////////////////////////////////////////////////////
+
+	// Map Former-supported viewports to Foundation 5 equivalents
+	'viewports' => array(
+		'large'  => 'large',
+		'medium' => null,
+		'small'  => 'small',
+		'mini'   => null,
+	),
+
+	// Width of labels for horizontal forms expressed as viewport => grid columns
+	'labelWidths' => array(
+		'small' => 3,
+	),
+
+	// Classes to be applied to wrapped labels in horizontal forms
+	'wrappedLabelClasses' => array('right','inline'),
+
+	// HTML markup and classes used by Foundation 5 for icons
+	'icon' => array(
+		'tag'    => 'i',
+		'set'    => null,
+		'prefix' => 'fi',
+	),
+
+    // CSS for inline validation errors
+    'error_classes' => array('class' => 'error')
+
+);

--- a/tests/Framework/ZurbFramework5Test.php
+++ b/tests/Framework/ZurbFramework5Test.php
@@ -1,0 +1,144 @@
+<?php
+namespace Former\Framework;
+
+use Former\TestCases\FormerTests;
+
+class ZurbFramework5Test extends FormerTests
+{
+
+	public function setUp()
+	{
+		parent::setUp();
+
+		$this->former->framework('ZurbFoundation5');
+		$this->former->horizontal_open()->__toString();
+	}
+
+	////////////////////////////////////////////////////////////////////
+	////////////////////////////// MATCHERS ////////////////////////////
+	////////////////////////////////////////////////////////////////////
+
+	public function matchLabel($name = 'foo', $field = 'foo', $required = false)
+	{
+		return array(
+			'tag'        => 'label',
+			'content'    => ucfirst($name),
+			'attributes' => array(
+				'for' => $field,
+			),
+		);
+	}
+
+	////////////////////////////////////////////////////////////////////
+	//////////////////////////////// TESTS /////////////////////////////
+	////////////////////////////////////////////////////////////////////
+
+	public function testCanUseMagicMethods()
+	{
+		$input   = $this->former->large_submit('Save')->__toString();
+		$matcher = $this->matchInputButton('large button', 'Save');
+
+		$this->assertHTML($matcher, $input);
+	}
+
+	public function testCanSetAnErrorStateOnAField()
+	{
+		$input   = $this->former->text('foo')->state('error')->__toString();
+		$matcher = array('tag' => 'div', 'attributes' => array('class' => 'error'));
+
+		$this->assertLabel($input);
+		$this->assertHTML($this->matchField(), $input);
+		$this->assertHTML($matcher, $input);
+	}
+
+	public function testCanAppendHelpTexts()
+	{
+		$input   = $this->former->text('foo')->inlineHelp('bar')->__toString();
+		$matcher = array('tag' => 'small', 'content' => 'Bar');
+
+		$this->assertLabel($input);
+		$this->assertHTML($this->matchField(), $input);
+		$this->assertHTML($matcher, $input);
+	}
+
+	public function testCantUseBootstrapReservedMethods()
+	{
+		$this->setExpectedException('BadMethodCallException');
+
+		$this->former->text('foo')->blockHelp('bar')->__toString();
+	}
+
+	public function testCreateIconWithFrameworkSpecificIcon()
+	{
+		$icon  = $this->app['former.framework']->createIcon('star')->__toString();
+		$match = '<i class="fi-star"></i>';
+
+		$this->assertEquals($match, $icon);
+	}
+
+	public function testCanAppendIcon()
+	{
+		$this->former->vertical_open();
+		$input = $this->former->text('foo')->appendIcon('star')->__toString();
+		$match = '<div>'.
+			'<label for="foo">Foo</label>'.
+			'<div class="row collapse">'.
+			'<div class="large-10 small-9 columns">'.
+			'<input id="foo" type="text" name="foo">'.
+			'</div>'.
+			'<div class="large-2 small-3 columns">'.
+			'<span class="postfix">'.
+			'<i class="fi-star"></i>'.
+			'</span>'.
+			'</div>'.
+			'</div>'.
+			'</div>';
+
+		$this->assertEquals($match, $input);
+	}
+
+	public function testCreateOverideIconSettingsWithFrameworkSpecificIcon()
+	{
+		$icon  = $this->app['former.framework']->createIcon('star')->__toString();
+		$match = '<i class="fi-star"></i>';
+
+		$this->assertEquals($match, $icon);
+	}
+
+	public function testVerticalFormInputField()
+	{
+		$this->former->vertical_open();
+		$field = $this->former->text('foo')->__toString();
+
+		$match = '<div>'.
+			'<label for="foo">Foo</label>'.
+			'<input id="foo" type="text" name="foo">'.
+			'</div>';
+
+		$this->assertEquals($match, $field);
+	}
+
+	public function testHorizontalFormInputField()
+	{
+		$field = $this->former->text('foo')->__toString();
+
+		$match = '<div class="row">'.
+			'<div class="small-3 columns">'.
+			'<label for="foo" class="right inline">Foo</label>'.
+			'</div>'.
+			'<div class="small-9 columns">'.
+			'<input id="foo" type="text" name="foo">'.
+			'</div>'.
+			'</div>';
+
+		$this->assertEquals($match, $field);
+	}
+
+	public function testHelpTextHasCorrectClasses()
+	{
+
+		$input   = $this->former->text('foo')->inlineHelp('bar')->__toString();
+		$matcher = array('tag' => 'small', 'attributes' => array('class' => 'error'), 'content' => 'Bar');
+		$this->assertHTML($matcher, $input);
+	}
+}

--- a/tests/TestCases/ContainerTestCase.php
+++ b/tests/TestCases/ContainerTestCase.php
@@ -171,6 +171,18 @@ abstract class ContainerTestCase extends PHPUnit_Framework_TestCase
 			),
 			'ZurbFoundation4.wrappedLabelClasses' => array('right', 'inline'),
 			'ZurbFoundation4.error_classes'       => array('class' => 'alert-box radius warning'),
+			'ZurbFoundation5.icon.prefix'         => 'fi',
+			'ZurbFoundation5.icon.set'            => null,
+			'ZurbFoundation5.icon.tag'            => 'i',
+			'ZurbFoundation5.labelWidths'         => array('small' => 3),
+			'ZurbFoundation5.viewports'           => array(
+				'large'  => 'large',
+				'medium' => null,
+				'small'  => 'small',
+				'mini'   => null
+			),
+			'ZurbFoundation5.wrappedLabelClasses' => array('right', 'inline'),
+			'ZurbFoundation5.error_classes'       => array('class' => 'error'),
 		), $options);
 
 		return $this->mock('config', 'Config', function ($mock) use ($options) {


### PR DESCRIPTION
Added support for Foundation 5.
I think the current implementation for Bootstrap is far more detailed than that for Foundation but this update will at least be at parity with the current support for Foundation 4.

this addresses issue #251
