### PR TITLE
In BS3, inline checkables ONLY have the *-inline class

### DIFF
--- a/src/Former/Traits/Checkable.php
+++ b/src/Former/Traits/Checkable.php
@@ -346,6 +346,10 @@ abstract class Checkable extends Field
 		// If inline items, add class
 		$isInline = $this->inline ? ' '.$this->app['former.framework']->getInlineLabelClass($this) : null;
 
+		// In Bootsrap 3, don't append the the checkable type (radio/checkbox) as a class if
+		// rendering inline.
+		$class = $this->app['former']->framework() == 'TwitterBootstrap3' ? trim($isInline) : $this->checkable.$isInline;
+
 		// Merge custom attributes with global attributes
 		$attributes = array_merge($this->attributes, $attributes);
 		if (!isset($attributes['id'])) {
@@ -370,7 +374,7 @@ abstract class Checkable extends Field
 			return (is_object($field)) ? $field->render() : $field;
 		}
 
-		return Element::create('label', $field.$label)->for($attributes['id'])->class($this->checkable.$isInline);
+		return Element::create('label', $field.$label)->for($attributes['id'])->class($class);
 	}
 
 	////////////////////////////////////////////////////////////////////

--- a/tests/Fields/CheckboxTest.php
+++ b/tests/Fields/CheckboxTest.php
@@ -36,7 +36,8 @@ class CheckboxTest extends FormerTests
 			'class' => 'checkbox',
 		);
 		if ($inline) {
-			$labelAttr['class'] .= $this->former->framework() === 'TwitterBootstrap3' ? ' checkbox-inline' : ' inline';
+			if ($this->former->framework() === 'TwitterBootstrap3') $labelAttr['class'] = 'checkbox-inline';
+			else $labelAttr['class'] .= ' inline';
 		}
 		if (!$checked) {
 			unset($checkAttr['checked']);

--- a/tests/Fields/RadioTest.php
+++ b/tests/Fields/RadioTest.php
@@ -35,7 +35,8 @@ class RadioTest extends FormerTests
 			'class' => 'radio',
 		);
 		if ($inline) {
-			$labelAttr['class'] .= $this->former->framework() === 'TwitterBootstrap3' ? ' radio-inline' : ' inline';
+			if ($this->former->framework() === 'TwitterBootstrap3') $labelAttr['class'] = 'radio-inline';
+			else $labelAttr['class'] .= ' inline';
 		}
 		if (!$checked) {
 			unset($radioAttr['checked']);


### PR DESCRIPTION
In Bootstrap 3, when radios and checkboxes are inline, their documentation has the class being **only** `checkbox-inline` and `radio-inline`.  They shouldn't **also** have `radio` or `checkbox`.

From [their docs](http://getbootstrap.com/css/#forms-controls):

``` html
<label class="checkbox-inline">
  <input type="checkbox" id="inlineCheckbox1" value="option1"> 1
</label>
<label class="radio-inline">
  <input type="radio" name="inlineRadioOptions" id="inlineRadio1" value="option1"> 1
</label>
```
