### PR TITLE
Update 'plaintext' field to pass W3C validation and replace <p> tag by <div> tag.

### DIFF
--- a/src/Former/Framework/TwitterBootstrap3.php
+++ b/src/Former/Framework/TwitterBootstrap3.php
@@ -364,6 +364,11 @@ class TwitterBootstrap3 extends Framework implements FrameworkInterface
 	 */
 	public function createPlainTextField(Field $field)
 	{
+		$label = $field->getLabel();
+		if ($label) {
+			$label->for('');
+		}
+
 		return Element::create('div', $field->getValue(), $field->getAttributes());
 	}
 

--- a/tests/Fields/PlainTextTest.php
+++ b/tests/Fields/PlainTextTest.php
@@ -24,6 +24,18 @@ class PlainTextTest extends FormerTests
 	}
 
 	/**
+	* Matches a plain label without 'for' attribute
+	*
+	* @return array
+	*/
+	public function matchPlainLabelWithBS3()
+	{
+		return array(
+			'tag' => 'label',
+		);
+	}
+
+	/**
 	 * Matches an plain text fallback input
 	 * Which is a disabled input
 	 *
@@ -73,7 +85,7 @@ class PlainTextTest extends FormerTests
 	 */
 	protected function formStaticGroup(
 		$input = '<div class="form-control-static" id="foo">bar</div>',
-		$label = '<label for="foo" class="control-label col-lg-2 col-sm-4">Foo</label>'
+		$label = '<label class="control-label col-lg-2 col-sm-4">Foo</label>'
 	) {
 		return $this->formGroup($input, $label);
 	}
@@ -103,7 +115,7 @@ class PlainTextTest extends FormerTests
 		$this->former->framework('TwitterBootstrap3');
 		$input = $this->former->plaintext('foo')->value('bar')->__toString();
 
-		$this->assertHTML($this->matchPlainLabel(), $input);
+		$this->assertHTML($this->matchPlainLabelWithBS3(), $input);
 		$this->assertHTML($this->matchPlainTextInput(), $input);
 
 		$matcher = $this->formStaticGroup();


### PR DESCRIPTION
-  Remove the `for` attribute of the `<label>` tag when we use `plaintext` field with TwitterBootstrap3 framework to pass W3C validation
- Use `<div>` tag instead of `<p>` tag for `plaintext` field with TwitterBootstrap3 framework to get more flexibility.  E.G. You can now store `<ul>` tag inside your `plaintext` field.

See: https://github.com/Anahkiasen/former/issues/377#issuecomment-56032144 and https://github.com/Anahkiasen/former/issues/377#issuecomment-56032654
