### PR TITLE
[Laravel] Update mime types to fix the 'accept' attribute of Former::file() field

### DIFF
--- a/src/Laravel/File.php
+++ b/src/Laravel/File.php
@@ -94,7 +94,7 @@ class File
 		'xht'   => 'application/xhtml+xml',
 		'xhtml' => 'application/xhtml+xml',
 		'xl'    => 'application/excel',
-		'xls'   => array('application/excel', 'application/vnd.ms-excel', 'application/msexcel'),
+		'xls'   => array('application/vnd.ms-excel', 'application/excel', 'application/msexcel'),
 		'xlsx'  => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 		'xml'   => 'text/xml',
 		'xsl'   => 'text/xml',


### PR DESCRIPTION
With Excel 2003 files and `mimes` live validation rules.

Otherwise Excel 2003-2007 files aren't listed in the input file dialog:
![input_file_types](https://cloud.githubusercontent.com/assets/5038872/4418500/50a778cc-4560-11e4-906b-f437878d9ea2.png)
