### PR TITLE
[Agnostic] The MAX_FILE_SIZE hidden field must precede the file input field.

### DIFF
--- a/src/Former/Form/Fields/File.php
+++ b/src/Former/Form/Fields/File.php
@@ -71,7 +71,7 @@ class File extends Field
 			? HtmlInput::hidden('MAX_FILE_SIZE', $this->maxSize)
 			: null;
 
-		return parent::render().$hidden;
+		return $hidden.parent::render();
 	}
 
 	////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fix #291
