### PR TITLE
[L4] Handle dot notation in live validation. Fixes #287

### DIFF
--- a/src/Former/Former.php
+++ b/src/Former/Former.php
@@ -462,6 +462,16 @@ class Former
 	 */
 	public function getRules($name)
 	{
-		return array_get($this->rules, $name);
+		// Check the rules for the name as given
+		$ruleset = array_get($this->rules, $name);
+
+		// If no rules found, convert to dot notation and try again
+		if (is_null($ruleset)) {
+			$name = str_replace(array('[', ']'), array('.', ''), $name);
+			$name = trim($name, '.');
+			$ruleset = array_get($this->rules, $name);
+		}
+
+		return $ruleset;
 	}
 }

--- a/tests/LiveValidationTest.php
+++ b/tests/LiveValidationTest.php
@@ -109,10 +109,50 @@ class LiveValidationTest extends FormerTests
 		$this->assertHTML($this->matchControlGroup(), $input);
 	}
 
+	public function testCanSetNestedBracketFieldAsRequired()
+	{
+		$this->former->withRules(array('foo[bar]' => 'required'));
+		$input = $this->former->text('foo[bar]')->name('foo')->__toString();
+
+		$this->assertHTML($this->matchField(array('required' => 'true')), $input);
+		$this->assertLabel($input, 'foo', true);
+		$this->assertHTML($this->matchControlGroup(), $input);
+	}
+
+	public function testCanSetNestedDotFieldAsRequired()
+	{
+		$this->former->withRules(array('foo.bar' => 'required'));
+		$input = $this->former->text('foo[bar]')->name('foo')->__toString();
+
+		$this->assertHTML($this->matchField(array('required' => 'true')), $input);
+		$this->assertLabel($input, 'foo', true);
+		$this->assertHTML($this->matchControlGroup(), $input);
+	}
+
 	public function testCanSetFieldAsRequiredAsArray()
 	{
 		$this->former->withRules(array('foo' => array('required')));
 		$input = $this->former->text('foo')->__toString();
+
+		$this->assertHTML($this->matchField(array('required' => 'true')), $input);
+		$this->assertLabel($input, 'foo', true);
+		$this->assertHTML($this->matchControlGroup(), $input);
+	}
+
+	public function testCanSetNestedBracketFieldAsRequiredAsArray()
+	{
+		$this->former->withRules(array('foo[bar]' => array('required')));
+		$input = $this->former->text('foo[bar]')->name('foo')->__toString();
+
+		$this->assertHTML($this->matchField(array('required' => 'true')), $input);
+		$this->assertLabel($input, 'foo', true);
+		$this->assertHTML($this->matchControlGroup(), $input);
+	}
+
+	public function testCanSetNestedDotFieldAsRequiredAsArray()
+	{
+		$this->former->withRules(array('foo.bar' => array('required')));
+		$input = $this->former->text('foo[bar]')->name('foo')->__toString();
 
 		$this->assertHTML($this->matchField(array('required' => 'true')), $input);
 		$this->assertLabel($input, 'foo', true);


### PR DESCRIPTION
This pull request fixes the issue where live validation does not work for nested fields, as described in issue #287.

Tests have been added to ensure that dot notation works, and also that bracket notation still works.  I only added the tests for the "required" rule, but I can duplicate the tests for all the other rules as well, if you'd like.

Let me know if I need to change anything.  Thanks!
