### PR TITLE
Allow repopulating multi-selects from Laravel relationships

### DIFF
--- a/src/Former/Form/Fields/Select.php
+++ b/src/Former/Form/Fields/Select.php
@@ -90,11 +90,16 @@ class Select extends Field
 			$this->name .= '[]';
 		}
 
-		$this->value = (array) $this->value;
+		if ( ! $this->value instanceOf \ArrayAccess) {
+			$this->value = (array) $this->value;
+		}
 
 		// Mark selected values as selected
 		if ($this->hasChildren() and !empty($this->value)) {
 			foreach ($this->value as $value) {
+				if (is_object($value) && method_exists($value, 'getKey')) {
+					$value = $value->getKey();
+				}
 				$this->selectValue($value);
 			}
 		}

--- a/tests/Fields/SelectTest.php
+++ b/tests/Fields/SelectTest.php
@@ -277,7 +277,40 @@ class SelectTest extends FormerTests
 		));
 
 		$select  = $this->former->select('foo')->fromQuery($collection)->select(array(1, 2))->render();
-		$matcher = '<select id="foo" name="foo"><option value="1" selected="selected">foo</option><option value="2" selected="selected">bar</option><option value="3">bar</option></select>';
+		$matcher =
+			'<select id="foo" name="foo">'.
+			'<option value="1" selected="selected">foo</option>'.
+			'<option value="2" selected="selected">bar</option>'.
+			'<option value="3">bar</option>'.
+			'</select>';
+
+		$this->assertEquals($matcher, $select);
+	}
+
+	public function testCanRepopulateFromCollection()
+	{
+		$model = new DummyEloquent;
+
+		$collection = new Collection(array(
+			new DummyEloquent(array('id' => 1, 'name' => 'foo')),
+			new DummyEloquent(array('id' => 2, 'name' => 'bar')),
+			new DummyEloquent(array('id' => 3, 'name' => 'bar')),
+		));
+
+		/**
+		 * $model->roles returns a Collection with id's of 1 and 3, so these ID's should end up selected
+		 */
+		$this->former->populate($model);
+		$select  = $this->former->select('roles')->fromQuery($collection)->__toString();
+
+		$matcher = $this->controlGroup(
+			'<select id="roles" name="roles">'.
+			'<option value="1" selected="selected">foo</option>'.
+			'<option value="2">bar</option>'.
+			'<option value="3" selected="selected">bar</option>'.
+			'</select>',
+			'<label for="roles" class="control-label">Roles</label>'
+			);
 
 		$this->assertEquals($matcher, $select);
 	}


### PR DESCRIPTION
This commit adds support for repopulating multi-selects from a model's relationships.

For example, if your `$model` has a `roles` relationship, and you add a `Former::multiselect('roles')` field, Former will now repopulate the multiselect from the values set on that relationship.

Seeking code review from others about this approach before merging. I initially tried to reuse the logic in `Helpers::queryToArray()` but found it unsuitable for the task, so I rolled my own.
