### PR TITLE
Only try to translate names with dots

### DIFF
--- a/src/Former/Helpers.php
+++ b/src/Former/Helpers.php
@@ -79,8 +79,9 @@ class Helpers
 			$translateFrom = str_replace(array(']', '['), array('', '.'), $translateFrom);
 		}
 
-		// Search for the key itself
-		if (static::$app['translator']->has($key)) {
+		// Search for the key itself, if it is valid
+		$validKey = preg_match("/^[a-z0-9_-]+([.][a-z0-9 _-]+)+$/i", $key) === 1;
+		if ($validKey && static::$app['translator']->has($key)) {
 			$translation = static::$app['translator']->get($key);
 		} elseif (static::$app['translator']->has($translateFrom)) {
 			$translation = static::$app['translator']->get($translateFrom);

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -45,4 +45,12 @@ class HelpersTest extends FormerTests
 		$input   = $this->former->text('address[city]')->__toString();
 		$this->assertHTML($matcher, $input);
 	}
+    
+    public function testDoesntTryInvalidKeys()
+    {
+        $input   = $this->former->text('Invalid Label?')->__toString();
+        $matcher = $this->matchLabel('Invalid Label?', 'Invalid Label?');
+
+        $this->assertHTML($matcher, $input);
+    }
 }

--- a/tests/TestCases/ContainerTestCase.php
+++ b/tests/TestCases/ContainerTestCase.php
@@ -297,10 +297,11 @@ abstract class ContainerTestCase extends PHPUnit_Framework_TestCase
 				->shouldReceive('get')->withAnyArgs()->andReturnUsing(function ($key) {
 					return $key;
 				})
-				->shouldReceive('has')->with('field_name_with_underscore')->andReturn(false)
-				->shouldReceive('has')->with('address.city')->andReturn(false)
-				->shouldReceive('has')->with('address[city]')->andReturn(false)
-				->shouldReceive('has')->withAnyArgs()->andReturn(true);
+				->shouldReceive('has')->with('pagination.next')->andReturn(true)
+				->shouldReceive('has')->with('pagination.previous')->andReturn(true)
+				->shouldReceive('has')->with('validation.attributes.address.city')->andReturn(true)
+                ->shouldReceive('has')->with('Invalid Label?')->andThrow(new \Exception("Invalid translation key"))
+				->shouldReceive('has')->withAnyArgs()->andReturn(false);
 		});
 	}
 


### PR DESCRIPTION
The labels etc are always tried to be translated. When you use something like `Active?` it tries to load `app/lang/en/Active?.php` which is unwanted because of the filesystem activity but also because of errors for certain filenames (atleast on windows with open_basedir restrictions..)

This might need some stricter check (regex to check if it's just a-z?)
