### PR TITLE
Extend fromQuery function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # Dependencies
 composer.lock
 vendor
+/composer.phar

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@
 # Dependencies
 composer.lock
 vendor
-/composer.phar
-/phpunit.phar

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 composer.lock
 vendor
 /composer.phar
+/phpunit.phar

--- a/src/Former/Form/Fields/Select.php
+++ b/src/Former/Form/Fields/Select.php
@@ -255,13 +255,13 @@ class Select extends Field
 	/**
 	 * Use the results from a Fluent/Eloquent query as options
 	 *
-	 * @param  array  $results An array of Eloquent models
-	 * @param  string $value   The attribute to use as text
-	 * @param  string $key     The attribute to use as value
+	 * @param  array           $results    An array of Eloquent models
+	 * @param  string|function $text       The value to use as text
+	 * @param  string|array    $attributes The data to use as attributes
 	 */
-	public function fromQuery($results, $value = null, $key = null)
+	public function fromQuery($results, $text = null, $attributes = null)
 	{
-		$this->options(Helpers::queryToArray($results, $value, $key));
+		$this->options(Helpers::queryToArray($results, $text, $attributes));
 
 		return $this;
 	}

--- a/src/Former/Helpers.php
+++ b/src/Former/Helpers.php
@@ -105,7 +105,7 @@ class Helpers
 	/**
 	 * Transforms an array of models into an associative array
 	 *
-	 * @param  array           $query      The array of results
+	 * @param  array|object    $query      The array of results
 	 * @param  string|function $text       The value to use as text
 	 * @param  string|array    $attributes The data to use as attributes
 	 *
@@ -185,7 +185,12 @@ class Helpers
 					$optionAttributeValue = '';
 				}
 
-				$array[$optionText][$optionAttributeName] = (string) $optionAttributeValue;
+				//For backward compatibility
+				if (count($attributes) === 1) {
+					$array[$optionAttributeValue] = (string) $optionText;
+				} else {
+					$array[$optionText][$optionAttributeName] = (string) $optionAttributeValue;
+				}
 			}
 		}
 

--- a/src/Former/Helpers.php
+++ b/src/Former/Helpers.php
@@ -105,13 +105,13 @@ class Helpers
 	/**
 	 * Transforms an array of models into an associative array
 	 *
-	 * @param  array|object $query The array of results
-	 * @param  string       $value The attribute to use as value
-	 * @param  string       $key   The attribute to use as key
+	 * @param  array           $query      The array of results
+	 * @param  string|function $text       The value to use as text
+	 * @param  string|array    $attributes The data to use as attributes
 	 *
 	 * @return array               A data array
 	 */
-	public static function queryToArray($query, $value = null, $key = null)
+	public static function queryToArray($query, $text = null, $attributes = null)
 	{
 		// Automatically fetch Lang objects for people who store translated options lists
 		// Same of unfetched queries
@@ -124,42 +124,71 @@ class Helpers
 			}
 		}
 
+		//Convert parametrs of old format to new format
+		if (!is_callable($text)) {
+			$optionTextValue = $text;
+			$text = function ($model) use($optionTextValue) {
+				if ($optionTextValue and isset($model->$optionTextValue)) {
+					return $model->$optionTextValue;
+				} elseif (method_exists($model, '__toString')) {
+					return  $model->__toString();
+				} else {
+					return null;
+				}
+			};
+		}
+
+		if (!is_array($attributes)) {
+			if (is_string($attributes)) {
+				$attributes = ['value' => $attributes];
+			} else {
+				$attributes = ['value' => null];
+			}
+		}
+
+		if (!isset($attributes['value'])) {
+			$attributes['value'] = null;
+		}
+		//-------------------------------------------------
+
 		// Populates the new options
 		foreach ($query as $model) {
-
 			// If it's an array, convert to object
 			if (is_array($model)) {
 				$model = (object) $model;
 			}
 
-			// Calculate the value
-			if ($value and isset($model->$value)) {
-				$modelValue = $model->$value;
-			} elseif (method_exists($model, '__toString')) {
-				$modelValue = $model->__toString();
-			} else {
-				$modelValue = null;
-			}
-
-			// Calculate the key
-			if ($key and isset($model->$key)) {
-				$modelKey = $model->$key;
-			} elseif (method_exists($model, 'getKey')) {
-				$modelKey = $model->getKey();
-			} elseif (isset($model->id)) {
-				$modelKey = $model->id;
-			} else {
-				$modelKey = $modelValue;
-			}
+			// Calculate option text
+			$optionText = $text($model);
 
 			// Skip if no text value found
-			if (!$modelValue) {
+			if (!$optionText) {
 				continue;
 			}
 
-			$array[$modelKey] = (string) $modelValue;
+			//Collect option attributes
+			foreach ($attributes as $optionAttributeName => $modelAttributeName) {
+				if (is_callable($modelAttributeName)) {
+					$optionAttributeValue = $modelAttributeName($model);
+				} elseif ($modelAttributeName and isset($model->$modelAttributeName)) {
+					$optionAttributeValue = $model->$modelAttributeName;
+				} elseif($optionAttributeName === 'value') {
+					//For backward compatibility
+					if (method_exists($model, 'getKey')) {
+						$optionAttributeValue = $model->getKey();
+					} elseif (isset($model->id)) {
+						$optionAttributeValue = $model->id;
+					} else {
+						$optionAttributeValue = $optionText;
+					}
+				} else {
+					$optionAttributeValue = '';
+				}
+
+				$array[$optionText][$optionAttributeName] = (string) $optionAttributeValue;
+			}
 		}
 
-		return isset($array) ? $array : $query;
+		return !empty($array) ? $array : $query;
 	}
 }

--- a/tests/Fields/SelectTest.php
+++ b/tests/Fields/SelectTest.php
@@ -159,6 +159,41 @@ class SelectTest extends FormerTests
 		$this->assertEquals($matcher, $select);
 	}
 
+	public function testSelectEloquentArrayWithOptionTextAsFunction()
+	{
+		$optionTextFunction = function($model) {
+			return $model->foo;
+		};
+		for ($i = 0; $i < 2; $i++) {
+			$eloquent[] = (object) array('age' => $i, 'foo' => 'bar');
+		}
+		$select  = $this->former->select('foo')->fromQuery($eloquent, $optionTextFunction, 'age')->__toString();
+		$matcher = $this->controlGroup('<select id="foo" name="foo"><option value="0">bar</option><option value="1">bar</option></select>');
+
+		$this->assertEquals($matcher, $select);
+	}
+
+	public function testSelectEloquentArrayWithOptionAttributes()
+	{
+		$optionTextFunction = function($model) {
+			return $model->foo . $model->age;
+		};
+		$optionDataFunction = function($model) {
+			return $model->foo;
+		};
+		$optionAttributes = [
+			'value' => 'age',
+			'data-test' => $optionDataFunction,
+		];
+		for ($i = 0; $i < 2; $i++) {
+			$eloquent[] = (object) array('age' => $i, 'foo' => 'bar');
+		}
+		$select  = $this->former->select('foo')->fromQuery($eloquent, $optionTextFunction, $optionAttributes)->__toString();
+		$matcher = $this->controlGroup('<select id="foo" name="foo"><option value="0" data-test="bar">bar0</option><option value="1" data-test="bar">bar1</option></select>');
+
+		$this->assertEquals($matcher, $select);
+	}
+
 	public function testNestedRelationships()
 	{
 		for ($i = 0; $i < 2; $i++) {


### PR DESCRIPTION
Added the ability to form `select` `option` with `data-*` attributes.
Added the ability to form `option` text through the passed function.
Use
```
		Former::select('foo')->fromQuery(
			$collection,
			function($model) {
				//return select option item text
			},
			[
				'value' => 'id',
				'data-test' => function($model) {
					//return select option item data-* attribute value
				}
			]
		);
```
The backward compatibility with existing code.