### PR TITLE
Numeric string detection

### DIFF
--- a/src/Former/Form/Fields/Select.php
+++ b/src/Former/Form/Fields/Select.php
@@ -131,7 +131,8 @@ class Select extends Field
 
 		foreach ($parent->getChildren() as $child) {
 			// Search by value
-			if ($child->getAttribute('value') === $value) {
+
+			if ($child->getAttribute('value') === $value || is_numeric($value) && $child->getAttribute('value') === (int)$value ) {
 				$child->selected('selected');
 			}
 

--- a/tests/Fields/SelectTest.php
+++ b/tests/Fields/SelectTest.php
@@ -103,6 +103,20 @@ class SelectTest extends FormerTests
         $this->assertEquals($matcher, $select);
     }
 
+    public function testSelectNumericString()
+    {
+        $select  = $this->former->select('foo')->value((string)0)->options($this->options)->placeholder('Pick something')->__toString();
+        $matcher = $this->controlGroup(
+            '<select id="foo" name="foo">'.
+            '<option value="" disabled="disabled">Pick something</option>'.
+            '<option value="0" selected="selected">baz</option>'.
+            '<option value="foo">bar</option>'.
+            '<option value="kal">ter</option>'.
+            '</select>');
+
+        $this->assertEquals($matcher, $select);
+    }
+
 	public function testSelectLang()
 	{
 		$select  = $this->former->select('foo')->options($this->translator->get('pagination'), 'previous')->__toString();


### PR DESCRIPTION
No option is selected if the value has been cast as a string, such as when from a form input, due to the new type comparison.

This keeps the type comparison in place, but casts strings as integers where appropriate. 