### PR TITLE
[Agnostic] FormerObject::getUniqueId only handles one duplicate

### DIFF
--- a/src/Former/Former.php
+++ b/src/Former/Former.php
@@ -69,6 +69,15 @@ class Former
 	 */
 	public $ids = array();
 
+	/**
+	 * A lookup table where the key is the input name,
+	 * and the value is number of times seen. This is
+	 * used to calculate unique ids.
+	 *
+	 * @var array
+	 */
+	public $names = array();
+
 	// Namespaces
 	////////////////////////////////////////////////////////////////////
 

--- a/src/Former/Traits/FormerObject.php
+++ b/src/Former/Traits/FormerObject.php
@@ -71,18 +71,16 @@ abstract class FormerObject extends Element
 	 */
 	protected function getUniqueId($name)
 	{
-		$existing = $this->app['former']->ids;
-		if (!in_array($name, $existing)) {
-			return $name;
+		$names = &$this->app['former']->names;
+
+		if (array_key_exists($name, $names)) {
+			$count = $names[$name] + 1;
+			$names[$name] = $count;
+			return $name . '-' . $count;
 		}
 
-		// Get the number of existing occurences
-		$existing = array_filter($existing, function ($value) use ($name) {
-			return $value == $name;
-		});
-		$existing = sizeof($existing) + 1;
-
-		return $name.'-'.$existing;
+		$names[$name] = 1;
+		return $name;
 	}
 
 	/**

--- a/tests/TestCases/FormerTests.php
+++ b/tests/TestCases/FormerTests.php
@@ -44,6 +44,7 @@ abstract class FormerTests extends ContainerTestCase
 	{
 		$this->former->labels = array();
 		$this->former->ids    = array();
+		$this->former->names  = array();
 	}
 
 	////////////////////////////////////////////////////////////////////

--- a/tests/Traits/FieldTest.php
+++ b/tests/Traits/FieldTest.php
@@ -189,11 +189,13 @@ class FieldTest extends FormerTests
 
 	public function testCantHaveDuplicateIdsForFields()
 	{
-		$field    = $this->former->text('name')->render();
-		$fieldTwo = $this->former->text('name')->render();
+		$field      = $this->former->text('name')->render();
+		$fieldTwo   = $this->former->text('name')->render();
+		$fieldThree = $this->former->text('name')->render();
 
 		$this->assertEquals('<input id="name" type="text" name="name">', $field);
 		$this->assertEquals('<input id="name-2" type="text" name="name">', $fieldTwo);
+		$this->assertEquals('<input id="name-3" type="text" name="name">', $fieldThree);
 	}
 
 	public function testCanChangeBindingOfField()


### PR DESCRIPTION
FormerObject::getUniqueId transforms "name" into "name-2", but will currently not generate a "name-3" since the value persisted in $ids (by setId) is the resulting value, not the original name.