### PR TITLE
Fix for Populator nested value lookup issue, et al.

### DIFF
--- a/src/Former/Populator.php
+++ b/src/Former/Populator.php
@@ -166,6 +166,10 @@ class Populator extends Collection
 			return is_null($value) ? $fallback : $value;
 		}
 
+		if ($model instanceof Collection) {
+			return $model->get($attribute, $fallback);
+		}
+
 		if (method_exists($model, 'toArray')) {
 			$model = $model->toArray();
 		} else {

--- a/src/Former/Populator.php
+++ b/src/Former/Populator.php
@@ -67,8 +67,21 @@ class Populator extends Collection
 			if (array_key_exists($relationship, $value)) {
 				$value = $value[$relationship];
 			} else {
+				// Check array for submodels that may contain the relationship
+				$inSubmodel = false;
+
 				foreach ($value as $key => $submodel) {
 					$value[$key] = $this->getAttributeFromModel($submodel, $relationship, $fallback);
+
+					if ($value[$key] !== $fallback) {
+						$inSubmodel = true;
+					}
+				}
+
+				// If no submodels contained the relationship, return the fallback, not an array of fallbacks
+				if (!$inSubmodel) {
+					$value = $fallback;
+					break;
 				}
 			}
 		}

--- a/src/Former/Populator.php
+++ b/src/Former/Populator.php
@@ -56,9 +56,6 @@ class Populator extends Collection
 			// Get attribute from model
 			if (!is_array($value)) {
 				$value = $this->getAttributeFromModel($value, $relationship, $fallback);
-				if ($value === $fallback) {
-					break;
-				}
 
 				continue;
 			}

--- a/src/Former/Populator.php
+++ b/src/Former/Populator.php
@@ -161,7 +161,9 @@ class Populator extends Collection
 	public function getAttributeFromModel($model, $attribute, $fallback)
 	{
 		if ($model instanceof Model) {
-			return $model->getAttribute($attribute);
+			// Return fallback if attribute is null
+			$value = $model->getAttribute($attribute);
+			return is_null($value) ? $fallback : $value;
 		}
 
 		if (method_exists($model, 'toArray')) {

--- a/src/Former/Populator.php
+++ b/src/Former/Populator.php
@@ -167,7 +167,7 @@ class Populator extends Collection
 			return $model->get($attribute, $fallback);
 		}
 
-		if (method_exists($model, 'toArray')) {
+		if (is_object($model) && method_exists($model, 'toArray')) {
 			$model = $model->toArray();
 		} else {
 			$model = (array) $model;

--- a/tests/Fields/CheckboxTest.php
+++ b/tests/Fields/CheckboxTest.php
@@ -633,5 +633,38 @@ class CheckboxTest extends FormerTests
 		$this->assertEquals($matcher, $checkbox);
 	}
 
+	public function testNestedCanSetNonOverriddenConstructorParameters()
+	{
+		$checkbox = $this->former->checkbox('foo[bar]', 'Foo Bar Label', 'bis', ['class' => 'ter'])->__toString();
+		$matcher  = $this->controlGroup(
+			'<input class="ter" id="foo[bar]" type="checkbox" name="foo[bar]" value="bis">',
+			'<label for="foo[bar]" class="control-label">Foo Bar Label</label>'
+		);
 
+		$this->assertEquals($matcher, $checkbox);
+	}
+
+	public function testNestedCanSetNonOverriddenConstructorParametersAndBeRepopulated()
+	{
+		$this->former->populate(array('foo' => array('bar' => 'bis')));
+		$checkbox = $this->former->checkbox('foo[bar]', 'Foo Bar Label', 'bis', ['class' => 'ter'])->__toString();
+		$matcher  = $this->controlGroup(
+			'<input class="ter" id="foo[bar]" type="checkbox" name="foo[bar]" checked="checked" value="bis">',
+			'<label for="foo[bar]" class="control-label">Foo Bar Label</label>'
+		);
+
+		$this->assertEquals($matcher, $checkbox);
+	}
+
+	public function testNestedShouldNotBeCheckedIfContstructorValueParameterIsOverridden()
+	{
+		$this->former->populate(array('foo' => array('bar' => 'bis')));
+		$checkbox = $this->former->checkbox('foo[bar]', null, 'bis', ['value' => 'ter'])->__toString();
+		$matcher  = $this->controlGroup(
+			'<input value="ter" id="foo[bar]" type="checkbox" name="foo[bar]">',
+			'<label for="foo[bar]" class="control-label">Foo[bar]</label>'
+		);
+
+		$this->assertEquals($matcher, $checkbox);
+	}
 }

--- a/tests/PopulatorTest.php
+++ b/tests/PopulatorTest.php
@@ -110,4 +110,248 @@ class PopulatorTest extends FormerTests
 
 		$this->assertEquals('foo', $populator->get('user.name'));
 	}
+
+	public function testCanGetArrayOfObjectValues()
+	{
+		$values    = array('foo' => (object) array('bar' => array('bis' => 'ter')));
+		$populator = new Populator($values);
+
+		$this->assertEquals('ter', $populator->get('foo[bar][bis]'));
+	}
+
+	public function testCanGetRelationshipAttribute()
+	{
+		$model     = new DummyEloquent(array('id' => 1, 'name' => 'foo'));
+		$populator = new Populator($model);
+
+		$this->assertEquals('foo', $populator->get('roles[0][name]'));
+	}
+
+	public function testCanGetRelationshipMutatedAttribute()
+	{
+		$model     = new DummyEloquent(array('id' => 1, 'name' => 'foo'));
+		$populator = new Populator($model);
+
+		$this->assertEquals('custom', $populator->get('roles[0][custom]'));
+	}
+
+	public function testCanGetRelationshipCollectionItemAttribute()
+	{
+		$model     = new DummyEloquent(array('id' => 1, 'name' => 'foo'));
+		$populator = new Populator($model);
+
+		$this->assertEquals('foo', $populator->get('rolesAsCollection[0][name]'));
+	}
+
+	public function testCanGetRelationshipCollectionItemMutatedAttribute()
+	{
+		$model     = new DummyEloquent(array('id' => 1, 'name' => 'foo'));
+		$populator = new Populator($model);
+
+		$this->assertEquals('custom', $populator->get('rolesAsCollection[0][custom]'));
+	}
+
+	public function testCanFallbackDefaultOnGetSingleValue()
+	{
+		$populator = new Populator(array('foo', 'bar'));
+
+		$this->assertEquals(null, $populator->get('bis'));
+	}
+
+	public function testCanFallbackCustomOnGetSingleValue()
+	{
+		$populator = new Populator(array('foo', 'bar'));
+
+		$this->assertEquals('custom', $populator->get('bis', 'custom'));
+	}
+
+	public function testCanFallbackDefaultOnNestedArrayValueMissingFirstIndex()
+	{
+		$populator = new Populator(array('foo' => array('bar' => array('bis' => 'ter'))));
+
+		$this->assertEquals(null, $populator->get('nofoo[bar][bis]'));
+	}
+
+	public function testCanFallbackCustomOnNestedArrayValueMissingFirstIndex()
+	{
+		$populator = new Populator(array('foo' => array('bar' => array('bis' => 'ter'))));
+
+		$this->assertEquals('custom', $populator->get('nofoo[bar][bis]', 'custom'));
+	}
+
+	public function testCanFallbackDefaultOnNestedArrayValueMissingMiddleIndex()
+	{
+		$populator = new Populator(array('foo' => array('bar' => array('bis' => 'ter'))));
+
+		$this->assertEquals(null, $populator->get('foo[nobar][bis]'));
+	}
+
+	public function testCanFallbackCustomOnNestedArrayValueMissingMiddleIndex()
+	{
+		$populator = new Populator(array('foo' => array('bar' => array('bis' => 'ter'))));
+
+		$this->assertEquals('custom', $populator->get('foo[nobar][bis]', 'custom'));
+	}
+
+	public function testCanFallbackDefaultOnNestedArrayValueMissingLastIndex()
+	{
+		$populator = new Populator(array('foo' => array('bar' => array('bis' => 'ter'))));
+
+		$this->assertEquals(null, $populator->get('foo[bar][nobis]'));
+	}
+
+	public function testCanFallbackCustomOnNestedArrayValueMissingLastIndex()
+	{
+		$populator = new Populator(array('foo' => array('bar' => array('bis' => 'ter'))));
+
+		$this->assertEquals('custom', $populator->get('foo[bar][nobis]', 'custom'));
+	}
+
+	public function testCanFallbackDefaultOnNestedArrayValueNotEnoughValues()
+	{
+		$populator = new Populator(array('foo' => 'bar'));
+
+		$this->assertEquals(null, $populator->get('foo[bar][bis]'));
+	}
+
+	public function testCanFallbackCustomOnNestedArrayValueNotEnoughValues()
+	{
+		$populator = new Populator(array('foo' => 'bar'));
+
+		$this->assertEquals('custom', $populator->get('foo[bar][bis]', 'custom'));
+	}
+
+	public function testCanFallbackDefaultOnNestedArrayValueMissingIndexNotSkipped()
+	{
+		$populator = new Populator(array('foo' => array('bar' => array('bis' => 'ter'))));
+
+		$this->assertEquals(null, $populator->get('foo[nobar][bar]'));
+	}
+
+	public function testCanFallbackCustomOnNestedArrayValueMissingIndexNotSkipped()
+	{
+		$populator = new Populator(array('foo' => array('bar' => array('bis' => 'ter'))));
+
+		$this->assertEquals('custom', $populator->get('foo[nobar][bar]', 'custom'));
+	}
+
+	public function testCanFallbackDefaultOnMissingAttribute()
+	{
+		$values    = (object) array('foo' => array('bar' => array('bis' => 'ter')));
+		$populator = new Populator($values);
+
+		$this->assertEquals(null, $populator->get('nofoo'));
+	}
+
+	public function testCanFallbackCustomOnMissingAttribute()
+	{
+		$values    = (object) array('foo' => array('bar' => array('bis' => 'ter')));
+		$populator = new Populator($values);
+
+		$this->assertEquals('custom', $populator->get('nofoo', 'custom'));
+	}
+
+	public function testCanFallbackDefaultOnMissingNestedArrayAttribute()
+	{
+		$values    = (object) array('foo' => array('bar' => array('bis' => 'ter')));
+		$populator = new Populator($values);
+
+		$this->assertEquals(null, $populator->get('foo[nobar]'));
+	}
+
+	public function testCanFallbackCustomOnMissingNestedArrayAttribute()
+	{
+		$values    = (object) array('foo' => array('bar' => array('bis' => 'ter')));
+		$populator = new Populator($values);
+
+		$this->assertEquals('custom', $populator->get('foo[nobar]', 'custom'));
+	}
+
+	public function testCanFallbackDefaultOnMissingNestedObjectAttribute()
+	{
+		$values    = (object) array('foo' => (object) array('bar' => array('bis' => 'ter')));
+		$populator = new Populator($values);
+
+		$this->assertEquals(null, $populator->get('foo[nobar]'));
+	}
+
+	public function testCanFallbackCustomOnMissingNestedObjectAttribute()
+	{
+		$values    = (object) array('foo' => (object) array('bar' => array('bis' => 'ter')));
+		$populator = new Populator($values);
+
+		$this->assertEquals('custom', $populator->get('foo[nobar]', 'custom'));
+	}
+
+	public function testCanFallbackDefaultOnMissingRelationshipAttribute()
+	{
+		$model     = new DummyEloquent(array('id' => 1, 'name' => 'foo'));
+		$populator = new Populator($model);
+
+		$this->assertEquals(null, $populator->get('roles[0][foo]'));
+	}
+
+	public function testCanFallbackCustomOnMissingRelationshipAttribute()
+	{
+		$model     = new DummyEloquent(array('id' => 1, 'name' => 'foo'));
+		$populator = new Populator($model);
+
+		$this->assertEquals('custom', $populator->get('roles[0][foo]', 'custom'));
+	}
+
+	public function testCanFallbackDefaultOnMissingRelationshipIndex()
+	{
+		$model     = new DummyEloquent(array('id' => 1, 'name' => 'foo'));
+		$populator = new Populator($model);
+
+		$this->assertEquals(null, $populator->get('roles[2][name]'));
+	}
+
+	public function testCanFallbackCustomOnMissingRelationshipIndex()
+	{
+		$model     = new DummyEloquent(array('id' => 1, 'name' => 'foo'));
+		$populator = new Populator($model);
+
+		$this->assertEquals('custom', $populator->get('roles[2][name]', 'custom'));
+	}
+
+	public function testCanFallbackDefaultOnMissingRelationshipCollectionItemAttribute()
+	{
+		$model     = new DummyEloquent(array('id' => 1, 'name' => 'foo'));
+		$populator = new Populator($model);
+
+		$this->assertEquals(null, $populator->get('rolesAsCollection[0][foo]'));
+	}
+
+	public function testCanFallbackCustomOnMissingRelationshipCollectionItemAttribute()
+	{
+		$model     = new DummyEloquent(array('id' => 1, 'name' => 'foo'));
+		$populator = new Populator($model);
+
+		$this->assertEquals('custom', $populator->get('rolesAsCollection[0][foo]', 'custom'));
+	}
+
+	public function testCanFallbackDefaultOnMissingRelationshipCollectionIndex()
+	{
+		$model     = new DummyEloquent(array('id' => 1, 'name' => 'foo'));
+		$populator = new Populator($model);
+
+		$this->assertEquals(null, $populator->get('rolesAsCollection[2][name]'));
+	}
+
+	public function testCanFallbackCustomOnMissingRelationshipCollectionIndex()
+	{
+		$model     = new DummyEloquent(array('id' => 1, 'name' => 'foo'));
+		$populator = new Populator($model);
+
+		$this->assertEquals('custom', $populator->get('rolesAsCollection[2][name]', 'custom'));
+	}
+
+	public function testCanAvoidFallbackCustom()
+	{
+		$values    = (object) array('foo' => (object) array('bar' => array('bis' => 'ter')));
+		$populator = new Populator($values);
+
+		$this->assertEquals('ter', $populator->get('foo[bar][bis]', array('bis' => 'ter')));
+	}
 }

--- a/tests/PopulatorTest.php
+++ b/tests/PopulatorTest.php
@@ -354,4 +354,11 @@ class PopulatorTest extends FormerTests
 
 		$this->assertEquals('ter', $populator->get('foo[bar][bis]', array('bis' => 'ter')));
 	}
+
+	public function testCanGetClassNamesImplementingToArray()
+	{
+		$populator = new Populator(array('foo' => '\Former\Dummy\DummyEloquent'));
+
+		$this->assertEquals('\Former\Dummy\DummyEloquent', $populator->get('foo[0]'));
+	}
 }


### PR DESCRIPTION
Fixes some issues with the `Populator` related to nested values.

Fixes issues:
#272: Checkbox whose name contains brackets is automatically checked.
#296: Check box default to selected
#314: Populator returns wrong input

The most important fix is for the issue detailed in #314. If you try to get a nested array value, and you supply an index that doesn't exist, you end up getting an array of fallback values (e.g. array of NULLs), instead of just the fallback value (e.g. NULL). This is basically what was also causing the issues with the checkboxes automatically being checked (issues #272 and #296).

Additional issues and fixes:
When trying to get an attribute from a `Model`, and the attribute doesn't exist, NULL would be returned, even if a custom fallback value (i.e. non-NULL) is provided. This has been corrected so that missing `Model` attributes can now return a custom fallback value if provided.

When trying to get an attribute from a `Collection` of `Models`, the `Populator` would call `toArray()` on the `Collection`, which would in turn call `toArray` on all the `Models`, turning them into standard arrays. If one then tries to get an attribute via an accessor on one of the nested `Models`, the value would not be available. This has been corrected so that the `Collection->get()` method will be used to get the underlying array of `Models`, instead of calling `toArray()` on the `Collection`.

Extreme edge case, but if a custom fallback value is provided and it matches an intermediate value in a chain of nested lookups, the lookup would break at that point and return the fallback instead of continuing on to the final destination. This has been corrected so that the lookup does not short circuit when it matches the fallback value.

Another edge case, but if a lookup value contains a string of the name of a class that implements to `toArray()` method, a fatal exception occurs when the `Populator` attempts to call `toArray()` on the string. This has been corrected so that it tests if the value is an object before attempting to call `toArray()` on it.

Many tests have been added regarding these issues, though not all necessarily fail initially.

Please let me know if there are any questions or issues.  Thanks!