### PR TITLE
Populate using models within an Eloquent\Collection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
     "mockery/mockery": "~0.9.1",
     "illuminate/database": "~5.0"
   },
+  "replace": {
+    "anahkiasen/former": "4.0.*"
+  },
   "autoload": {
     "psr-4": {
       "Former\\": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "anahkiasen/former",
+  "name": "weotch/former",
   "description": "A powerful form builder",
   "homepage": "http://anahkiasen.github.com/former/",
   "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "illuminate/database": "~5.0"
   },
   "replace": {
-    "anahkiasen/former": "4.0.*"
+    "anahkiasen/former": "4.1.*"
   },
   "autoload": {
     "psr-4": {

--- a/src/Former/Populator.php
+++ b/src/Former/Populator.php
@@ -1,6 +1,7 @@
 <?php
 namespace Former;
 
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -149,7 +150,7 @@ class Populator extends Collection
 	/**
 	 * Get an attribute from a model
 	 *
-	 * @param object $model     The model
+	 * @param object $model     The model or collection
 	 * @param string $attribute The attribute's name
 	 * @param string $fallback  Fallback value
 	 *
@@ -161,6 +162,10 @@ class Populator extends Collection
 			// Return fallback if attribute is null
 			$value = $model->getAttribute($attribute);
 			return is_null($value) ? $fallback : $value;
+		}
+
+		if ($model instanceof EloquentCollection) {
+			return $model->find($attribute, $fallback);
 		}
 
 		if ($model instanceof Collection) {


### PR DESCRIPTION
Say you have a an Article model that is one-to-many with Images:

``` php
class Article {
  public function images() { return $this->hasMany('App\Image'); }
}
```

This PR allows you to populate a form using specific instances of that child.  For instance:

``` php
Former::populate(App\Article::first());
echo Former::text('images[2][title]');
```

This will look for the value of that field as if you did:

``` php
$article->images->find(2)->title
```
