### PR TITLE
Proper initialization of Group->help property

### DIFF
--- a/src/Former/Form/Group.php
+++ b/src/Former/Form/Group.php
@@ -43,9 +43,9 @@ class Group extends Tag
 	/**
 	 * The group help
 	 *
-	 * @var string
+	 * @var array
 	 */
-	protected $help = null;
+	protected $help = array();
 
 	/**
 	 * An array of elements to preprend the field


### PR DESCRIPTION
I have checked and `$help` property has never been a string but an array of strings, since the first commit.

The `array()` initialization permits to use it flawlessly in array functions. Prevents cataclysms such as in #514.