### PR TITLE
Properly reset rules attribute when closing forms

### DIFF
--- a/src/Former/Former.php
+++ b/src/Former/Former.php
@@ -427,7 +427,7 @@ class Former
 
 		// Reset all values
 		$this->errors = null;
-		$this->rules  = null;
+		$this->rules  = array();
 
 		return isset($closing) ? $closing : null;
 	}


### PR DESCRIPTION
Similarly to #515, intends to prevent regressions.

Fixes that goddamn #516.

Thanks @dgallinari for reporting!