### PR TITLE
Multiple rules on a field

### DIFF
--- a/src/Former/Traits/Field.php
+++ b/src/Former/Traits/Field.php
@@ -258,6 +258,36 @@ abstract class Field extends FormerObject implements FieldInterface
 		return $this;
 	}
 
+    /**
+     * Apply multiple rules passed as a string.
+     *
+     * @param $rules
+     * @return $this
+     */
+    public function rules($rules)
+    {
+        foreach (explode('|', $rules) as $rule) {
+            $parameters = null;
+
+            // If we have a rule with a value
+            if (($colon = strpos($rule, ':')) !== false) {
+                $parameters = str_getcsv(substr($rule, $colon + 1));
+            }
+
+            // Exclude unsupported rules
+            $rule = is_numeric($colon) ? substr($rule, 0, $colon) : $rule;
+
+            // Store processed rule in Former's array
+            if (!isset($parameters)) {
+                $parameters = array();
+            }
+
+            call_user_func_array([$this, 'rule'], array_merge([$rule], $parameters));
+        }
+
+        return $this;
+    }
+
 	/**
 	 * Adds a label to the group/field
 	 *

--- a/tests/LiveValidationTest.php
+++ b/tests/LiveValidationTest.php
@@ -543,6 +543,15 @@ class LiveValidationTest extends FormerTests
 		$this->assertHTML($matcher, $input);
 	}
 
+	public function testCanApplyMultipleRulesWithString()
+    {
+        $input   = $this->former->number('foo')->rules('max:10|required')->__toString();
+        $matcher = $this->matchField(array('max' => 10, 'required' => true), 'number');
+
+        $this->assertControlGroup($input);
+        $this->assertHTML($matcher, $input);
+    }
+
 	public function testCanCreateMaxFileSizeForFiles()
 	{
 		$input = $this->former->file('foo')->rule('max', 10)->__toString();


### PR DESCRIPTION
Added a function to set multiple rules on a field with a string.

Example:
`Former::text('name')->rules('required|alpha')`
`Former::text('name')->rules(Model::$rules['name'])`
