### PR TITLE
Update Elements.php

### DIFF
--- a/src/Former/Form/Elements.php
+++ b/src/Former/Form/Elements.php
@@ -43,7 +43,7 @@ class Elements
 	 */
 	public function token()
 	{
-		$csrf = $this->session->getToken();
+		$csrf = $this->session->token();
 
 		return (string) $this->app['former']->hidden('_token', $csrf);
 	}


### PR DESCRIPTION
Laravel 5.4 removed session->getToken() in place of session->token()

(However I'm not sure if this would be compatible with older laravel versions and may need a new branch/version)