### PR TITLE
Fix broken binding

### DIFF
--- a/src/Former/FormerServiceProvider.php
+++ b/src/Former/FormerServiceProvider.php
@@ -103,7 +103,7 @@ class FormerServiceProvider extends ServiceProvider
 			if (method_exists($request, 'setSessionStore')) {
 				$request->setSessionStore($app['session']);
 			} else {
-				$request->setSession($app['session']);
+				$request->setLaravelSession($app['session']);
 			}
 
 			return $request;


### PR DESCRIPTION
Fixes issue https://github.com/formers/former/issues/551
as suggested by eugen-pasca.
Without it, the currently published framework is unusable (at least the configuration I'm using with composer 4.1.1)
I tried to run tests on both the 4.1.1 tag and the top of the branch, but they are failing. I'm assuming there's some work in progress there.

Here's the exception I'm getting. This solution fixes 4.1.1.

Fatal error: Uncaught TypeError: Argument 1 passed to Symfony\Component\HttpFoundation\Request::setSession() must be an instance of Symfony\Component\HttpFoundation\Session\SessionInterface, instance of Illuminate\Session\Store given, called in D:\home\site\wwwroot\vendor\anahkiasen\former\src\Former\FormerServiceProvider.php on line 106 and defined in D:\home\site\wwwroot\vendor\symfony\http-foundation\Request.php:864 Stack trace: #0 D:\home\site\wwwroot\vendor\anahkiasen\former\src\Former\FormerServiceProvider.php(106): Symfony\Component\HttpFoundation\Request->setSession(Object(Illuminate\Session\Store)) #1 D:\home\site\wwwroot\vendor\illuminate\container\Container.php(726): Former\FormerServiceProvider->Former\{closure}(Object(Illuminate\Container\Container), Array) #2 D:\home\site\wwwroot\vendor\illuminate\container\Container.php(608): Illuminate\Container\Container->build(Object(Closure)) #3 D:\home\site\wwwroot\vendor\illuminate\container\Container.php(575): Illuminate\Container\Container->resolve('request') #4 D:\ in D:\home\site\wwwroot\vendor\symfony\http-foundation\Request.php on line 864 