### PR TITLE
Fix Bootstrap 4 validation messages not being colored red

### DIFF
--- a/src/Former/Form/Group.php
+++ b/src/Former/Form/Group.php
@@ -435,9 +435,9 @@ class Group extends Tag
 
 		// Replace help text with error if any found
 		$errors = $this->app['former']->getErrors();
-        if ($errors and $this->app['former']->getOption('error_messages')) {
-            $inline = $this->app['former.framework']->createValidationError($errors);
-        }
+		if ($errors and $this->app['former']->getOption('error_messages')) {
+			$inline = $this->app['former.framework']->createValidationError($errors);
+		}
 
 		return join(null, array($inline, $block));
 	}

--- a/src/Former/Form/Group.php
+++ b/src/Former/Form/Group.php
@@ -435,9 +435,9 @@ class Group extends Tag
 
 		// Replace help text with error if any found
 		$errors = $this->app['former']->getErrors();
-		if ($errors and $this->app['former']->getOption('error_messages')) {
-			$inline = $this->app['former.framework']->createHelp($errors);
-		}
+        if ($errors and $this->app['former']->getOption('error_messages')) {
+            $inline = $this->app['former.framework']->createValidationError($errors);
+        }
 
 		return join(null, array($inline, $block));
 	}

--- a/src/Former/Framework/TwitterBootstrap4.php
+++ b/src/Former/Framework/TwitterBootstrap4.php
@@ -336,7 +336,7 @@ class TwitterBootstrap4 extends Framework implements FrameworkInterface
 	 */
 	public function createHelp($text, $attributes = array())
 	{
-		return Element::create('span', $text, $attributes)->addClass('form-text text-muted');
+		return Element::create('small', $text, $attributes)->addClass('text-muted');
 	}
 
 	/**
@@ -362,7 +362,7 @@ class TwitterBootstrap4 extends Framework implements FrameworkInterface
 	 */
 	public function createBlockHelp($text, $attributes = array())
 	{
-		return Element::create('p', $text, $attributes)->addClass('form-text text-muted');
+		return Element::create('small', $text, $attributes)->addClass('form-text text-muted');
 	}
 
 	/**

--- a/src/Former/Framework/TwitterBootstrap4.php
+++ b/src/Former/Framework/TwitterBootstrap4.php
@@ -65,9 +65,8 @@ class TwitterBootstrap4 extends Framework implements FrameworkInterface
 	 * @var array
 	 */
 	protected $states = array(
-		'has-warning',
-		'has-error',
-		'has-success',
+		'is-valid',
+		'is-invalid',
 	);
 
 	/**
@@ -158,7 +157,7 @@ class TwitterBootstrap4 extends Framework implements FrameworkInterface
 	 */
 	public function errorState()
 	{
-		return 'has-error';
+		return 'is-invalid';
 	}
 
 	/**
@@ -239,6 +238,10 @@ class TwitterBootstrap4 extends Framework implements FrameworkInterface
 				)) and !in_array('form-control', $classes)
 		) {
 			$classes[] = 'form-control';
+		}
+
+		if ($this->app['former']->getErrors($field->getName())) {
+			$classes[] = $this->errorState();
 		}
 
 		return $this->addClassesToField($field, $classes);

--- a/src/Former/Framework/TwitterBootstrap4.php
+++ b/src/Former/Framework/TwitterBootstrap4.php
@@ -65,7 +65,6 @@ class TwitterBootstrap4 extends Framework implements FrameworkInterface
 	 * @var array
 	 */
 	protected $states = array(
-		'is-valid',
 		'is-invalid',
 	);
 
@@ -339,6 +338,19 @@ class TwitterBootstrap4 extends Framework implements FrameworkInterface
 	{
 		return Element::create('span', $text, $attributes)->addClass('form-text text-muted');
 	}
+
+    /**
+     * Render an validation error text
+     *
+     * @param string $text
+     * @param array  $attributes
+     *
+     * @return string
+     */
+    public function createValidationError($text, $attributes = array())
+    {
+        return Element::create('div', $text, $attributes)->addClass('invalid-feedback');
+    }
 
 	/**
 	 * Render an help text

--- a/src/Former/Framework/TwitterBootstrap4.php
+++ b/src/Former/Framework/TwitterBootstrap4.php
@@ -339,18 +339,18 @@ class TwitterBootstrap4 extends Framework implements FrameworkInterface
 		return Element::create('span', $text, $attributes)->addClass('form-text text-muted');
 	}
 
-    /**
-     * Render an validation error text
-     *
-     * @param string $text
-     * @param array  $attributes
-     *
-     * @return string
-     */
-    public function createValidationError($text, $attributes = array())
-    {
-        return Element::create('div', $text, $attributes)->addClass('invalid-feedback');
-    }
+	/**
+	 * Render an validation error text
+	 *
+	 * @param string $text
+	 * @param array  $attributes
+	 *
+	 * @return string
+	 */
+	public function createValidationError($text, $attributes = array())
+	{
+		return Element::create('div', $text, $attributes)->addClass('invalid-feedback');
+	}
 
 	/**
 	 * Render an help text

--- a/src/Former/Traits/Framework.php
+++ b/src/Former/Traits/Framework.php
@@ -311,20 +311,20 @@ abstract class Framework implements FrameworkInterface
 		return $label;
 	}
 
-    ////////////////////////////////////////////////////////////////////
-    //////////////////////////// RENDER BLOCKS /////////////////////////
-    ////////////////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////
+	//////////////////////////// RENDER BLOCKS /////////////////////////
+	////////////////////////////////////////////////////////////////////
 
-    /**
-     * Render an validation error text
-     *
-     * @param string $text
-     * @param array  $attributes
-     *
-     * @return string
-     */
-    public function createValidationError($text, $attributes = array())
-    {
-        return $this->createHelp($text, $attributes);
-    }
+	/**
+	 * Render an validation error text
+	 *
+	 * @param string $text
+	 * @param array  $attributes
+	 *
+	 * @return string
+	 */
+	public function createValidationError($text, $attributes = array())
+	{
+		return $this->createHelp($text, $attributes);
+	}
 }

--- a/src/Former/Traits/Framework.php
+++ b/src/Former/Traits/Framework.php
@@ -1,12 +1,13 @@
 <?php
 namespace Former\Traits;
 
+use Former\Interfaces\FrameworkInterface;
 use HtmlObject\Element;
 
 /**
  * Base helpers and common methods to all frameworks
  */
-abstract class Framework
+abstract class Framework implements FrameworkInterface
 {
 	/**
 	 * The Container
@@ -309,4 +310,21 @@ abstract class Framework
 	{
 		return $label;
 	}
+
+    ////////////////////////////////////////////////////////////////////
+    //////////////////////////// RENDER BLOCKS /////////////////////////
+    ////////////////////////////////////////////////////////////////////
+
+    /**
+     * Render an validation error text
+     *
+     * @param string $text
+     * @param array  $attributes
+     *
+     * @return string
+     */
+    public function createValidationError($text, $attributes = array())
+    {
+        return $this->createHelp($text, $attributes);
+    }
 }

--- a/tests/Framework/TwitterBootstrap4Test.php
+++ b/tests/Framework/TwitterBootstrap4Test.php
@@ -138,10 +138,10 @@ class TwitterBootstrap4Test extends FormerTests
 
 		$required = $this->former->text('required')->__toString();
 		$matcher  =
-			'<div class="form-group has-error">'.
+			'<div class="form-group is-invalid">'.
 			'<label for="required" class="control-label">Required</label>'.
-			'<input class="form-control" id="required" type="text" name="required">'.
-			'<span class="form-text text-muted">The required field is required.</span>'.
+			'<input class="form-control is-invalid" id="required" type="text" name="required">'.
+			'<div class="invalid-feedback">The required field is required.</div>'.
 			'</div>';
 
 		$this->assertEquals($matcher, $required);


### PR DESCRIPTION
I have not touched the other frameworks because time and not having all the knowledge. However this opens up the possibility to differentiate between validation error help messages and just plain help messages (like a user would post).

Also fixed Bootstrap 4 needing `is-invalid` instead of `has-error` and add that class to the actual input element, on the group it has no effect.

Also some fixes to the actual help blocks and matched them to how they're displayed in the documentation, relevant sections:

- https://getbootstrap.com/docs/4.1/components/forms/#help-text
- https://getbootstrap.com/docs/4.1/components/forms/#server-side

Result:

![image](https://user-images.githubusercontent.com/1090754/47606539-fb975480-da14-11e8-8f62-350e2299961f.png)

