### PR TITLE
Encode checkbox value to prevent XSS attack

### DIFF
--- a/src/Former/Traits/Checkable.php
+++ b/src/Former/Traits/Checkable.php
@@ -359,7 +359,7 @@ abstract class Checkable extends Field
 		}
 
 		// Create field
-		$field = Input::create($this->checkable, $name, $value, $attributes);
+		$field = Input::create($this->checkable, $name, Helpers::encode($value), $attributes);
 		if ($this->isChecked($item, $value)) {
 			$field->checked('checked');
 		}


### PR DESCRIPTION
Hi,

The default behavior of Former is to use $_GET variables to populate the form fields, If I understood correctly.

This makes a XSS attack possible because checkbox are not escaping their values.

A similar fix was made here in 2014 for hidden inputs: https://github.com/formers/former/commit/58596440993dd09e77724e24afdbb229e227946b

I had a hard time trying to use the right version for the tests, since there's no composer.lock, but when I got it right all tests passed.

## Steps to reproduce:

* Create new Laravel app
* Install Former through Composer
* Add code to welcome.blade.php: 
`{!! Former::checkbox('test') !!}`
* run php artisan serve
* Open URL: 
```
http://127.0.0.1:8000/?test="><h1><i>some HTML here</i></h1>
```

## Expected behavior:

* Value would be escaped/encoded, no HTML would be rendered

## What happens:

* HTML is displayed (XSS attack)

