### PR TITLE
On pages without an open tag, this would currently fail

### DIFF
--- a/src/Former/Framework/TwitterBootstrap4.php
+++ b/src/Former/Framework/TwitterBootstrap4.php
@@ -253,7 +253,7 @@ class TwitterBootstrap4 extends Framework implements FrameworkInterface
 	 */
 	public function getGroupClasses()
 	{
-		if ($this->app['former.form']->isOfType('horizontal')) {
+		if (isset($this->app['former.form']) and $this->app['former.form']->isOfType('horizontal')) {
 			return 'form-group row';
 		} else {
 			return 'form-group';


### PR DESCRIPTION
With this change it now works as it does with TwitterBoostrap3 where there is no optional class depending on type of form in the open tag.