### PR TITLE
Adds correct checkbox input class when is a checkbox (or radio)

### DIFF
--- a/src/Former/Framework/TwitterBootstrap4.php
+++ b/src/Former/Framework/TwitterBootstrap4.php
@@ -215,6 +215,8 @@ class TwitterBootstrap4 extends Framework implements FrameworkInterface
 	{
 		// Add inline class for checkables
 		if ($field->isCheckable()) {
+			// Adds correct checkbox input class when is a checkbox (or radio)
+			$field->addClass('form-check-input');
 			$classes[] = 'form-check';
 
 			if (in_array('inline', $classes)) {


### PR DESCRIPTION
Without this, the default form-input class is used which isn't styling checkboxes or radios correctly