### PR TITLE
Laravel 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
+  - 7.2
+  - 7.3
   - nightly
 
 # This triggers builds to run on the new TravisCI infrastructure.
@@ -13,7 +14,6 @@ sudo: false
 cache:
   directories:
     - $HOME/.composer/cache
-
 
 before_script:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --no-interaction --prefer-dist --dev
+  - travis_retry composer install --no-interaction --prefer-dist
 
 matrix:
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -18,18 +18,18 @@
   "require": {
     "php": ">=5.4.0",
     "anahkiasen/html-object": "~1.4",
-    "illuminate/config": "~5.0|~6.0",
-    "illuminate/container": "~5.0|~6.0",
-    "illuminate/http": "~5.0|~6.0",
-    "illuminate/routing": "~5.0|~6.0",
-    "illuminate/session": "~5.0|~6.0",
-    "illuminate/translation": "~5.0|~6.0",
-    "illuminate/support": "~5.0|~6.0"
+    "illuminate/config": "~5.0|^6.0",
+    "illuminate/container": "~5.0|^6.0",
+    "illuminate/http": "~5.0|^6.0",
+    "illuminate/routing": "~5.0|^6.0",
+    "illuminate/session": "~5.0|^6.0",
+    "illuminate/translation": "~5.0|^6.0",
+    "illuminate/support": "~5.0|^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4",
     "mockery/mockery": "~0.9.1",
-    "illuminate/database": "~5.0|~6.0"
+    "illuminate/database": "~5.0|^6.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,18 @@
   "require": {
     "php": ">=5.4.0",
     "anahkiasen/html-object": "~1.4",
-    "illuminate/config": "~5.0",
-    "illuminate/container": "~5.0",
-    "illuminate/http": "~5.0",
-    "illuminate/routing": "~5.0",
-    "illuminate/session": "~5.0",
-    "illuminate/translation": "~5.0"
+    "illuminate/config": "~5.0|~6.0",
+    "illuminate/container": "~5.0|~6.0",
+    "illuminate/http": "~5.0|~6.0",
+    "illuminate/routing": "~5.0|~6.0",
+    "illuminate/session": "~5.0|~6.0",
+    "illuminate/translation": "~5.0|~6.0",
+    "illuminate/support": "~5.0|~6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4",
     "mockery/mockery": "~0.9.1",
-    "illuminate/database": "~5.0"
+    "illuminate/database": "~5.0|~6.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Former/Form/Actions.php
+++ b/src/Former/Form/Actions.php
@@ -3,6 +3,7 @@ namespace Former\Form;
 
 use Former\Traits\FormerObject;
 use Illuminate\Container\Container;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 /**
@@ -70,9 +71,9 @@ class Actions extends FormerObject
 	{
 		// Dynamically add buttons to an actions block
 		if ($this->isButtonMethod($method)) {
-			$text       = array_get($parameters, 0);
-			$link       = array_get($parameters, 1);
-			$attributes = array_get($parameters, 2);
+			$text       = Arr::get($parameters, 0);
+			$link       = Arr::get($parameters, 1);
+			$attributes = Arr::get($parameters, 2);
 			if (!$attributes and is_array($link)) {
 				$attributes = $link;
 			}

--- a/src/Former/Form/Fields/Choice.php
+++ b/src/Former/Form/Fields/Choice.php
@@ -6,6 +6,7 @@ use Former\Traits\Field;
 use HtmlObject\Element;
 use HtmlObject\Input;
 use Illuminate\Container\Container;
+use Illuminate\Support\Str;
 
 /**
  * Everything list-related (select, multiselect, ...)
@@ -80,13 +81,13 @@ class Choice extends Field
 		if ($choices) {
 			$this->choices($choices);
 		}
-		
+
 		parent::__construct($app, $type, $name, $label, $selected, $attributes);
-		
+
 		$this->setChoiceType();
 
 		// Nested models population
-		if (str_contains($this->name, '.') and is_array($this->value) and !empty($this->value) and is_string($this->value[key($this->value)])) {
+		if (Str::contains($this->name, '.') and is_array($this->value) and !empty($this->value) and is_string($this->value[key($this->value)])) {
 			$this->fromQuery($this->value);
 			$this->value = $selected ?: null;
 		}
@@ -129,7 +130,7 @@ class Choice extends Field
 			$field->multiple();
 			$name .= '[]';
 		}
-		
+
 		$field->setAttribute('name', $name);
 
 		$field->nest($this->getOptions());
@@ -140,7 +141,7 @@ class Choice extends Field
 	public function getOptions()
 	{
 		$children = [];
-		
+
 		// Add placeholder text if any
 		if ($placeholder = $this->getPlaceholder()) {
 			$children[] = $placeholder;
@@ -226,7 +227,7 @@ class Choice extends Field
 			if ($this->options['isMultiple']) {
 				$name .= '[]';
 			}
-		
+
 			if(!isset($attributes['id'])) {
 				$attributes['id'] = $this->id.'_'.count($children);
 			}
@@ -239,7 +240,7 @@ class Choice extends Field
 			$class = $this->app['former']->framework() == 'TwitterBootstrap3' ? trim($isInline) : $choiceType.$isInline;
 
 			$element = Input::create($choiceType, $name, $inputValue, $attributes);
-			
+
 			// $element->setAttribute('name', $name);
 
 			if ($this->hasValue($inputValue)) {
@@ -253,7 +254,7 @@ class Choice extends Field
 				$labelElement = Element::create('label', $rendered.$label);
 				$element = $labelElement->for($attributes['id'])->class($class);
 			}
-			
+
 			// If BS3, if checkables are stacked, wrap them in a div with the checkable type
 			if (!$isInline && $this->app['former']->framework() == 'TwitterBootstrap3') {
 				$wrapper = Element::create('div', $element->render())->class($choiceType);
@@ -266,7 +267,7 @@ class Choice extends Field
 			$children[] = $element;
 		}
 		$field->nest($children);
-		
+
 		return $field;
 	}
 
@@ -412,7 +413,7 @@ class Choice extends Field
 
 		return $this;
 	}
-	
+
 	/**
 	 * Set isMultiple
 	 *
@@ -426,7 +427,7 @@ class Choice extends Field
 
 		return $this;
 	}
-	
+
 	/**
 	 * Set isExpanded
 	 *
@@ -484,5 +485,5 @@ class Choice extends Field
 	{
 		return $this->choices;
 	}
-	
+
 }

--- a/src/Former/Form/Fields/Select.php
+++ b/src/Former/Form/Fields/Select.php
@@ -5,6 +5,7 @@ use Former\Helpers;
 use Former\Traits\Field;
 use HtmlObject\Element;
 use Illuminate\Container\Container;
+use Illuminate\Support\Str;
 
 /**
  * Everything list-related (select, multiselect, ...)
@@ -67,7 +68,7 @@ class Select extends Field
 		parent::__construct($app, $type, $name, $label, $selected, $attributes);
 
 		// Nested models population
-		if (str_contains($this->name, '.') and is_array($this->value) and !empty($this->value) and is_string($this->value[key($this->value)])) {
+		if (Str::contains($this->name, '.') and is_array($this->value) and !empty($this->value) and is_string($this->value[key($this->value)])) {
 			$this->fromQuery($this->value);
 			$this->value = $selected ?: null;
 		}

--- a/src/Former/Form/Form.php
+++ b/src/Former/Form/Form.php
@@ -4,6 +4,7 @@ namespace Former\Form;
 use Former\Populator;
 use Former\Traits\FormerObject;
 use Illuminate\Container\Container;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 /**
@@ -111,10 +112,10 @@ class Form extends FormerObject
 	 */
 	public function openForm($type, $parameters)
 	{
-		$action     = array_get($parameters, 0);
-		$method     = array_get($parameters, 1, 'POST');
-		$attributes = array_get($parameters, 2, array());
-		$secure     = array_get($parameters, 3, null);
+		$action     = Arr::get($parameters, 0);
+		$method     = Arr::get($parameters, 1, 'POST');
+		$attributes = Arr::get($parameters, 2, array());
+		$secure     = Arr::get($parameters, 3, null);
 
 		// Fetch errors if asked for
 		if ($this->app['former']->getOption('fetch_errors')) {
@@ -334,7 +335,7 @@ class Form extends FormerObject
 			// Get string by uses
 		} else {
 			foreach ($this->app['router']->getRoutes() as $route) {
-				$routeUses = method_exists($route, 'getOption') ? $route->getOption('_uses') : array_get($route->getAction(), 'controller');
+				$routeUses = method_exists($route, 'getOption') ? $route->getOption('_uses') : Arr::get($route->getAction(), 'controller');
 				if ($action = $routeUses) {
 					if ($action == $name) {
 						break;
@@ -345,7 +346,7 @@ class Form extends FormerObject
 
 		// Get method
 		$methods = method_exists($route, 'getMethods') ? $route->getMethods() : $route->methods();
-		$method  = array_get($methods, 0);
+		$method  = Arr::get($methods, 0);
 
 		return $method;
 	}

--- a/src/Former/Form/Group.php
+++ b/src/Former/Form/Group.php
@@ -6,6 +6,7 @@ use Former\Helpers;
 use HtmlObject\Element;
 use HtmlObject\Traits\Tag;
 use Illuminate\Container\Container;
+use Illuminate\Support\Arr;
 
 /**
  * Helper class to build groups
@@ -430,8 +431,8 @@ class Group extends Tag
 	 */
 	protected function getHelp()
 	{
-		$inline = array_get($this->help, 'inline');
-		$block  = array_get($this->help, 'block');
+		$inline = Arr::get($this->help, 'inline');
+		$block  = Arr::get($this->help, 'block');
 
 		// Replace help text with error if any found
 		$errors = $this->app['former']->getErrors();

--- a/src/Former/Former.php
+++ b/src/Former/Former.php
@@ -5,6 +5,7 @@ use Closure;
 use Former\Exceptions\InvalidFrameworkException;
 use Former\Traits\Field;
 use Illuminate\Container\Container;
+use Illuminate\Support\Arr;
 use Illuminate\Support\MessageBag;
 use Illuminate\Contracts\Validation\Validator;
 
@@ -148,12 +149,12 @@ class Former
 		// Checking for any supplementary classes
 		$modifiers = explode('_', $method);
 		$method  = array_pop($modifiers);
-		
+
 		// Dispatch to the different Form\Fields
 		$field     = $this->dispatch->toFields($method, $parameters);
 		$field->setModifiers($modifiers);
 		$field->addClass('');
-		
+
 		// Else bind field
 		$this->app->instance('former.field', $field);
 
@@ -481,13 +482,13 @@ class Former
 	public function getRules($name)
 	{
 		// Check the rules for the name as given
-		$ruleset = array_get($this->rules, $name);
+		$ruleset = Arr::get($this->rules, $name);
 
 		// If no rules found, convert to dot notation and try again
 		if (is_null($ruleset)) {
 			$name = str_replace(array('[', ']'), array('.', ''), $name);
 			$name = trim($name, '.');
-			$ruleset = array_get($this->rules, $name);
+			$ruleset = Arr::get($this->rules, $name);
 		}
 
 		return $ruleset;

--- a/src/Former/Framework/TwitterBootstrap.php
+++ b/src/Former/Framework/TwitterBootstrap.php
@@ -6,6 +6,7 @@ use Former\Traits\Field;
 use Former\Traits\Framework;
 use HtmlObject\Element;
 use Illuminate\Container\Container;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 /**
@@ -287,7 +288,7 @@ class TwitterBootstrap extends Framework implements FrameworkInterface
 		}
 
 		// Create tag
-		$tag  = array_get($iconSettings, 'tag', $this->iconTag);
+		$tag  = Arr::get($iconSettings, 'tag', $this->iconTag);
 		$icon = Element::create($tag, null, $attributes);
 
 		// White icons ignore user overrides to use legacy Bootstrap styling
@@ -298,8 +299,8 @@ class TwitterBootstrap extends Framework implements FrameworkInterface
 			$set    = null;
 			$prefix = 'icon';
 		} else {
-			$set    = array_get($iconSettings, 'set', $this->iconSet);
-			$prefix = array_get($iconSettings, 'prefix', $this->iconPrefix);
+			$set    = Arr::get($iconSettings, 'set', $this->iconSet);
+			$prefix = Arr::get($iconSettings, 'prefix', $this->iconPrefix);
 		}
 		$icon->addClass("$set $prefix-$iconType");
 

--- a/src/Former/MethodDispatcher.php
+++ b/src/Former/MethodDispatcher.php
@@ -3,6 +3,7 @@ namespace Former;
 
 use Closure;
 use Illuminate\Container\Container;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 /**
@@ -145,8 +146,8 @@ class MethodDispatcher
 		// Create opener
 		$group = new Form\Group(
 			$this->app,
-			array_get($parameters, 0, null),
-			array_get($parameters, 1, null)
+			Arr::get($parameters, 0, null),
+			Arr::get($parameters, 1, null)
 		);
 
 		// Set custom group as true
@@ -190,12 +191,12 @@ class MethodDispatcher
 		$field = new $class(
 			$this->app,
 			$method,
-			array_get($parameters, 0),
-			array_get($parameters, 1),
-			array_get($parameters, 2),
-			array_get($parameters, 3),
-			array_get($parameters, 4),
-			array_get($parameters, 5)
+			Arr::get($parameters, 0),
+			Arr::get($parameters, 1),
+			Arr::get($parameters, 2),
+			Arr::get($parameters, 3),
+			Arr::get($parameters, 4),
+			Arr::get($parameters, 5)
 		);
 
 		return $field;

--- a/src/Former/Populator.php
+++ b/src/Former/Populator.php
@@ -42,7 +42,7 @@ class Populator extends Collection
 		}
 
 		// Plain array
-		if (is_array($this->items) and !str_contains($field, '[')) {
+		if (is_array($this->items) and !Str::contains($field, '[')) {
 			return parent::get($field, $fallback);
 		}
 

--- a/src/Former/Traits/Checkable.php
+++ b/src/Former/Traits/Checkable.php
@@ -5,7 +5,9 @@ use Former\Helpers;
 use HtmlObject\Element;
 use HtmlObject\Input;
 use Illuminate\Container\Container;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 /**
  * Abstract methods inherited by Checkbox and Radio
@@ -85,7 +87,7 @@ abstract class Checkable extends Field
 	public function __construct(Container $app, $type, $name, $label, $value, $attributes)
 	{
 		// Unify auto and chained methods of grouping checkboxes
-		if (ends_with($name, '[]')) {
+		if (Str::endsWith($name, '[]')) {
 			$name = substr($name, 0, -2);
 			$this->grouped();
 		}
@@ -106,7 +108,7 @@ abstract class Checkable extends Field
 	 */
 	public function __call($method, $parameters)
 	{
-		$focused = $this->setOnFocused('attributes.'.$method, array_get($parameters, 0));
+		$focused = $this->setOnFocused('attributes.'.$method, Arr::get($parameters, 0));
 		if ($focused) {
 			return $this;
 		}
@@ -304,7 +306,7 @@ abstract class Checkable extends Field
 			// If we gave custom information on the item, add them
 			if (is_array($name)) {
 				$attributes = $name;
-				$name       = array_get($attributes, 'name', $fallback);
+				$name       = Arr::get($attributes, 'name', $fallback);
 				unset($attributes['name']);
 			}
 
@@ -386,7 +388,7 @@ abstract class Checkable extends Field
 			$element = $field . Element::create('label', $label)->for($attributes['id'])->class($class)->render();
 
 			$wrapper_class = $this->inline ? 'form-check form-check-inline' : 'form-check';
-			
+
 			$element = Element::create('div', $element)->class($wrapper_class)->render();
 
 		} else {
@@ -450,7 +452,7 @@ abstract class Checkable extends Field
 			return false;
 		}
 
-		$this->items[$this->focus] = array_set($this->items[$this->focus], $attribute, $value);
+		$this->items[$this->focus] = Arr::set($this->items[$this->focus], $attribute, $value);
 
 		return $this;
 	}
@@ -474,12 +476,12 @@ abstract class Checkable extends Field
 		if ($this->isCheckbox() or
 			!$this->isCheckbox() and !$this->items
 		) {
-			$checked = array_get($this->checked, $name, false);
+			$checked = Arr::get($this->checked, $name, false);
 
 			// If there are multiple, search for the value
 			// as the name are the same between radios
 		} else {
-			$checked = array_get($this->checked, $value, false);
+			$checked = Arr::get($this->checked, $value, false);
 		}
 
 		// Check the values and POST array

--- a/src/Former/Traits/Framework.php
+++ b/src/Former/Traits/Framework.php
@@ -3,6 +3,7 @@ namespace Former\Traits;
 
 use Former\Interfaces\FrameworkInterface;
 use HtmlObject\Element;
+use Illuminate\Support\Arr;
 
 /**
  * Base helpers and common methods to all frameworks
@@ -201,9 +202,9 @@ abstract class Framework implements FrameworkInterface
 		}
 
 		// icon settings can be overridden for a specific icon
-		$tag    = array_get($iconSettings, 'tag', $this->iconTag);
-		$set    = array_get($iconSettings, 'set', $this->iconSet);
-		$prefix = array_get($iconSettings, 'prefix', $this->iconPrefix);
+		$tag    = Arr::get($iconSettings, 'tag', $this->iconTag);
+		$set    = Arr::get($iconSettings, 'set', $this->iconSet);
+		$prefix = Arr::get($iconSettings, 'prefix', $this->iconPrefix);
 
 		return Element::create($tag, null, $attributes)->addClass("$set $prefix-$iconType");
 	}

--- a/tests/Fields/HiddenTest.php
+++ b/tests/Fields/HiddenTest.php
@@ -2,6 +2,7 @@
 namespace Former\Fields;
 
 use Former\TestCases\FormerTests;
+use Illuminate\Support\Arr;
 
 class HiddenTest extends FormerTests
 {
@@ -10,7 +11,7 @@ class HiddenTest extends FormerTests
 	{
 		$input   = $this->former->hidden('foo')->value('bar')->__toString();
 		$matcher = $this->matchField(array(), 'hidden');
-		$field   = array_except($matcher, 'id');
+		$field   = Arr::except($matcher, 'id');
 
 		$this->assertHTML($field, $input);
 	}
@@ -21,12 +22,12 @@ class HiddenTest extends FormerTests
 
 		$input                        = $this->former->hidden('foo')->value('bis')->__toString();
 		$matcher                      = $this->matchField(array(), 'hidden');
-		$field                        = array_except($matcher, 'id');
+		$field                        = Arr::except($matcher, 'id');
 		$field['attributes']['value'] = 'bar';
 
 		$this->assertHTML($field, $input);
 	}
-	
+
 	public function testEncodedValue()
 	{
 		$input = $this->former->hidden('foo')->value('<a>bar</a>')->__toString();

--- a/tests/Fields/InputTest.php
+++ b/tests/Fields/InputTest.php
@@ -4,6 +4,7 @@ namespace Former\Fields;
 use Former\Dummy\DummyEloquent;
 use Former\TestCases\FormerTests;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Arr;
 
 class HtmlValue implements Htmlable {
 
@@ -34,7 +35,7 @@ class InputTest extends FormerTests
 		$this->mockConfig(array('automatic_label' => false));
 
 		$input      = $this->former->text('foo')->__toString();
-		$matchField = array_except($this->matchField(), 'id');
+		$matchField = Arr::except($this->matchField(), 'id');
 
 		$this->assertHTML($this->matchControlGroup(), $input);
 		$this->assertHTML($matchField, $input);
@@ -43,7 +44,7 @@ class InputTest extends FormerTests
 	public function testCanCreateSingleTextWithoutLabelOnStart()
 	{
 		$input      = $this->former->text('foo', '')->__toString();
-		$matchField = array_except($this->matchField(), 'id');
+		$matchField = Arr::except($this->matchField(), 'id');
 
 		$this->assertHTML($this->matchControlGroup(), $input);
 		$this->assertHTML($matchField, $input);
@@ -52,7 +53,7 @@ class InputTest extends FormerTests
 	public function testCanCreateSingleTextWithoutLabel()
 	{
 		$input      = $this->former->text('foo')->label(null)->__toString();
-		$matchField = array_except($this->matchField(), 'id');
+		$matchField = Arr::except($this->matchField(), 'id');
 
 		$this->assertHTML($this->matchControlGroup(), $input);
 		$this->assertHTML($matchField, $input);
@@ -62,7 +63,7 @@ class InputTest extends FormerTests
 	{
 		$input      = $this->former->search('foo')->__toString();
 		$matchField = $this->matchField();
-		array_set($matchField, 'attributes.class', 'search-query');
+		Arr::set($matchField, 'attributes.class', 'search-query');
 
 		$this->assertControlGroup($input);
 		$this->assertHTML($matchField, $input);
@@ -74,7 +75,7 @@ class InputTest extends FormerTests
 
 		$input = $this->former->text('foo')->data('foo')->class('bar')->__toString();
 		$label = $this->matchLabel('Foo');
-		array_forget($label, 'attributes.class');
+		Arr::forget($label, 'attributes.class');
 
 		$this->assertHTML($label, $input);
 		$this->assertHTML($this->matchField(), $input);

--- a/tests/TestCases/ContainerTestCase.php
+++ b/tests/TestCases/ContainerTestCase.php
@@ -3,6 +3,7 @@ namespace Former\TestCases;
 
 use Former\FormerServiceProvider;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Foundation\Application;
 use Mockery;
 use PHPUnit_Framework_TestCase;
 
@@ -31,7 +32,12 @@ abstract class ContainerTestCase extends PHPUnit_Framework_TestCase
 	public function setUp()
 	{
 		if (!static::$appCache) {
-			$this->app = FormerServiceProvider::make();
+			// Added to prevent issues with the missing method used in Laravel 6+
+			MacroableContainer::macro('configurationIsCached', function () {
+				return false;
+			});
+
+			$this->app = FormerServiceProvider::make(new MacroableContainer);
 
 			// Setup Illuminate
 			$this->mockSession();

--- a/tests/TestCases/MacroableContainer.php
+++ b/tests/TestCases/MacroableContainer.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Former\TestCases;
+
+use Illuminate\Container\Container;
+use Illuminate\Support\Traits\Macroable;
+
+class MacroableContainer extends Container
+{
+	use Macroable;
+}


### PR DESCRIPTION
Looks like not much has changed in 6 related to Former and tests are green after the changes needed to make the container work in the tests.

Would be greatly appreciated if someone could take a look at this and it could be merged and tagged so we can upgrade our apps to Laravel 6.