### PR TITLE
Fix errors when using rules in validation array

### DIFF
--- a/src/Former/Former.php
+++ b/src/Former/Former.php
@@ -307,6 +307,9 @@ class Former
 			}
 
 			foreach ($expFieldRules as $rule) {
+				if (is_object($rule)) {
+					continue;
+				}
 
 				$parameters = null;
 

--- a/tests/LiveValidationTest.php
+++ b/tests/LiveValidationTest.php
@@ -626,4 +626,15 @@ class LiveValidationTest extends FormerTests
         $this->assertHTML($hiddenMaxSizeMatcher1, $input1);
         $this->assertNotHTML($hiddenMaxSizeMatcher2, $input2);
     }
+
+	public function testCanIgnoreValidationRuleClasses()
+	{
+		$this->former->withRules(array('foo' => array('required', new \stdClass())));
+
+		$input   = $this->former->text('foo')->__toString();
+		$matcher = $this->matchField();
+
+		$this->assertHTML($matcher, $input);
+		$this->assertControlGroup($input);
+	}
 }


### PR DESCRIPTION
This fixes errors when using [rule objects](https://laravel.com/docs/6.x/validation#using-rule-objects).

We might want to see if we can support all the different rule objects and convert them to Former rules but that will be a thing for the future.

For now this prevents Former form crashing when a Rule object is introduced into the rules of an element.

Related: #580 (want to keep this open to track supporting rule objects)