### PR TITLE
Fixes for PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "php": ">=7.2.0",
+    "php": "^7.2|^8.0",
     "anahkiasen/html-object": "~1.4",
     "illuminate/config": "~5.0|^6.0|^7.0|^8.0",
     "illuminate/container": "~5.0|^6.0|^7.0|^8.0",

--- a/src/Former/Helpers.php
+++ b/src/Former/Helpers.php
@@ -116,7 +116,7 @@ class Helpers
 		// Automatically fetch Lang objects for people who store translated options lists
 		// Same of unfetched queries
 		if (!$query instanceof Collection) {
-			if (method_exists($query, 'get')) {
+			if ((is_object($query) || is_string($query)) && method_exists($query, 'get')) {
 				$query = $query->get();
 			}
 			if (!is_array($query)) {
@@ -127,10 +127,10 @@ class Helpers
 		//Convert parametrs of old format to new format
 		if (!is_callable($text)) {
 			$optionTextValue = $text;
-			$text = function ($model) use($optionTextValue) {
+			$text = function ($model) use ($optionTextValue) {
 				if ($optionTextValue and isset($model->$optionTextValue)) {
 					return $model->$optionTextValue;
-				} elseif (method_exists($model, '__toString')) {
+				} elseif ((is_object($model) || is_string($model)) && method_exists($model, '__toString')) {
 					return  $model->__toString();
 				} else {
 					return null;

--- a/src/Former/Traits/Field.php
+++ b/src/Former/Traits/Field.php
@@ -132,7 +132,7 @@ abstract class Field extends FormerObject implements FieldInterface
 		}
 
 		// Redirect calls to the Control Group
-		if (method_exists($this->group, $method) or Str::startsWith($method, 'onGroup')) {
+		if (method_exists($this->group ?: '', $method) or Str::startsWith($method, 'onGroup')) {
 			$method = str_replace('onGroup', '', $method);
 			$method = lcfirst($method);
 

--- a/src/Former/Traits/Field.php
+++ b/src/Former/Traits/Field.php
@@ -132,7 +132,7 @@ abstract class Field extends FormerObject implements FieldInterface
 		}
 
 		// Redirect calls to the Control Group
-		if (method_exists($this->group ?: '', $method) or Str::startsWith($method, 'onGroup')) {
+		if ((!empty($this->group) && method_exists($this->group, $method)) or Str::startsWith($method, 'onGroup')) {
 			$method = str_replace('onGroup', '', $method);
 			$method = lcfirst($method);
 

--- a/tests/Fields/InputTest.php
+++ b/tests/Fields/InputTest.php
@@ -87,7 +87,7 @@ class InputTest extends FormerTests
 
 		$input = $this->former->text('foo')->data('foo')->class('bar')->__toString();
 
-		$label = array('tag' => 'label', 'content' => 'Foo', array('for' => 'foo'));
+		$label = array('tag' => 'label', 'content' => 'Foo', 'attributes' => array('for' => 'foo'));
 		$this->assertHTML($label, $input);
 		$this->assertHTML($this->matchField(), $input);
 

--- a/tests/TestCases/FormerTests.php
+++ b/tests/TestCases/FormerTests.php
@@ -8,6 +8,7 @@ use Mockery;
 use DOMNode;
 use DOMDocument;
 use DOMNodeList;
+use PHPUnit\Framework\Exception;
 use PHPUnit\Util\Xml;
 
 /**
@@ -416,7 +417,7 @@ abstract class FormerTests extends ContainerTestCase
         }
 
         if (!empty($unknown)) {
-            throw new PHPUnit_Framework_Exception(
+            throw new Exception(
                 'Unknown key(s): ' . implode(', ', $unknown)
             );
         }


### PR DESCRIPTION
In php 8 method_exists' first value cannot default to null, must be object or string.

Was throwing error: method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given.