### PR TITLE
Fix addons with Bootstrap 4

### DIFF
--- a/src/Former/Form/Group.php
+++ b/src/Former/Form/Group.php
@@ -469,7 +469,7 @@ class Group extends Tag
 	{
 		// Iterate over the items and place them where they should
 		foreach ((array) $items as $item) {
-			$item             = $this->app['former.framework']->placeAround($item);
+			$item             = $this->app['former.framework']->placeAround($item, $place);
 			$this->{$place}[] = $item;
 		}
 	}

--- a/src/Former/Framework/TwitterBootstrap4.php
+++ b/src/Former/Framework/TwitterBootstrap4.php
@@ -415,12 +415,12 @@ class TwitterBootstrap4 extends Framework implements FrameworkInterface
 		$items = (array) $item;
 		$element = '';
 		foreach ($items as $item) {
-			$hasHtmlTag = strpos(ltrim($item), '<') === 0;
+			$hasButtonTag = strpos(ltrim($item), '<button') === 0;
 
 			// Get class to use
-			$class = $hasHtmlTag ? '' : 'input-group-text';
+			$class = $hasButtonTag ? '' : 'input-group-text';
 
-			$element .= $hasHtmlTag ? $item : Element::create('span', $item)->addClass($class);
+			$element .= $hasButtonTag ? $item : Element::create('span', $item)->addClass($class);
 		}
 
 		return Element::create('div', $element)->addClass('input-group-'.$place);

--- a/src/Former/Framework/TwitterBootstrap4.php
+++ b/src/Former/Framework/TwitterBootstrap4.php
@@ -405,17 +405,25 @@ class TwitterBootstrap4 extends Framework implements FrameworkInterface
 	 *
 	 * @return Element A wrapped item
 	 */
-	public function placeAround($item)
+	public function placeAround($item, $place = null)
 	{
 		// Render object
 		if (is_object($item) and method_exists($item, '__toString')) {
 			$item = $item->__toString();
 		}
 
-		// Get class to use
-		$class = (strpos($item, '<button') !== false) ? 'btn' : 'addon';
+		$items = (array) $item;
+		$element = '';
+		foreach ($items as $item) {
+			$hasHtmlTag = strpos(ltrim($item), '<') === 0;
 
-		return Element::create('span', $item)->addClass('input-group-'.$class);
+			// Get class to use
+			$class = $hasHtmlTag ? '' : 'input-group-text';
+
+			$element .= $hasHtmlTag ? $item : Element::create('span', $item)->addClass($class);
+		}
+
+		return Element::create('div', $element)->addClass('input-group-'.$place);
 	}
 
 	/**

--- a/tests/Framework/TwitterBootstrap4Test.php
+++ b/tests/Framework/TwitterBootstrap4Test.php
@@ -65,7 +65,7 @@ class TwitterBootstrap4Test extends FormerTests
 		$icon  = $this->former->text('foo')->prependIcon('thumbs-up')->__toString();
 		$match = $this->vmatch('<label for="foo" class="control-label">Foo</label>',
 			'<div class="input-group">'.
-			'<span class="input-group-addon"><i class="fa fa-thumbs-up"></i></span>'.
+			'<div class="input-group-prepend"><span class="input-group-text"><i class="fa fa-thumbs-up"></i></span></div>'.
 			'<input class="form-control" id="foo" type="text" name="foo">'.
 			'</div>');
 
@@ -79,7 +79,7 @@ class TwitterBootstrap4Test extends FormerTests
 		$match = $this->vmatch('<label for="foo" class="control-label">Foo</label>',
 			'<div class="input-group">'.
 			'<input class="form-control" id="foo" type="text" name="foo">'.
-			'<span class="input-group-addon"><i class="fa fa-thumbs-up"></i></span>'.
+			'<div class="input-group-append"><span class="input-group-text"><i class="fa fa-thumbs-up"></i></span></div>'.
 			'</div>');
 		$this->assertEquals($match, $icon);
 	}
@@ -202,10 +202,10 @@ class TwitterBootstrap4Test extends FormerTests
 		$this->former->close();
 	}
 
-	public function testButtonsAreWrappedInSpecialClass()
+	public function testButtonsAreNotWrapped()
 	{
 		$button  = $this->former->text('foo')->append($this->former->button('Search'))->wrapAndRender();
-		$matcher = '<span class="input-group-btn"><button class="btn" type="button">Search</button></span>';
+		$matcher = '<button class="btn" type="button">Search</button>';
 
 		$this->assertStringContainsString($matcher, $button);
 	}


### PR DESCRIPTION
Usage with Laravel:
```blade
{{-- Basic text addon --}}
{!! Former::open()->method('GET') !!}
    {!! Former::text('test2')->append('&euro;') !!}
{!! Former::close() !!}

{{-- Icon addon --}}
{!! Former::open()->method('GET') !!}
    {!! Former::text('test icon')->append('<i class="fa fa-thumbs-up"></i>') !!}
{!! Former::close() !!}

{{-- Multiple text addons --}}
{!! Former::open()->method('GET') !!}
    {!! Former::text('test3')->append(['&euro;', 'second']) !!}
{!! Former::close() !!}

{{-- Button addon --}}
{!! Former::open()->method('GET') !!}
  {!! Former::text('test4')->append('<button class="btn">OK</button>') !!}
{!! Former::close() !!}

{{-- Button addons --}}
{!! Former::open()->method('GET') !!}
  {!! Former::text('test5')->append(['<button class="btn">OK</button>', '<button class="btn">2</button>']) !!}
{!! Former::close() !!}
```

Credits: @mrextreme

Reference:
https://github.com/formers/former/issues/581#issuecomment-473243405