### PR TITLE
Add missing 'form-check-label' class and fix invalid feedback for Bootstrap 4

### DIFF
--- a/src/Former/Form/Group.php
+++ b/src/Former/Form/Group.php
@@ -175,8 +175,17 @@ class Group extends Tag
 	public function wrapField($field)
 	{
 		$label = $this->getLabel($field);
+		$help = $this->getHelp();
+		if ($field->isCheckable() && $this->app['former']->framework() == 'TwitterBootstrap4') {
+			$wrapperClass = $field->isInline() ? 'form-check form-check-inline' : 'form-check';
+			if ($this->app['former']->getErrors($field->getName())) {
+				$hiddenInput = Element::create('input', null, ['type' => 'hidden'])->class('form-check-input is-invalid');
+				$help = $hiddenInput.$help;
+			}
+			$help = Element::create('div', $help)->class($wrapperClass);
+		}
 		$field = $this->prependAppend($field);
-		$field .= $this->getHelp();
+		$field .= $help;
 
 		return $this->wrap($field, $label);
 	}

--- a/src/Former/Traits/Checkable.php
+++ b/src/Former/Traits/Checkable.php
@@ -257,6 +257,17 @@ abstract class Checkable extends Field
 		return $this;
 	}
 
+
+	/**
+	 * Check if the checkables are inline
+	 *
+	 * @return boolean
+	 */
+	public function isInline()
+	{
+		return $this->inline;
+	}
+
 	////////////////////////////////////////////////////////////////////
 	////////////////////////// INTERNAL METHODS ////////////////////////
 	////////////////////////////////////////////////////////////////////
@@ -391,7 +402,6 @@ abstract class Checkable extends Field
 			$wrapper_class = $this->inline ? 'form-check form-check-inline' : 'form-check';
 
 			$element = Element::create('div', $element)->class($wrapper_class)->render();
-
 		} else {
 			// Original way is to add the 'input' inside the 'label'
 			$element = Element::create('label', $field.$label)->for($attributes['id'])->class($class)->render();

--- a/src/Former/Traits/Checkable.php
+++ b/src/Former/Traits/Checkable.php
@@ -385,7 +385,8 @@ abstract class Checkable extends Field
 			$element = (is_object($field)) ? $field->render() : $field;
 		} elseif ($this->app['former']->framework() == 'TwitterBootstrap4') {
 			// Revised for Bootstrap 4, move the 'input' outside of the 'label'
-			$element = $field . Element::create('label', $label)->for($attributes['id'])->class($class)->render();
+			$labelClass = 'form-check-label';
+			$element = $field . Element::create('label', $label)->for($attributes['id'])->class($labelClass)->render();
 
 			$wrapper_class = $this->inline ? 'form-check form-check-inline' : 'form-check';
 


### PR DESCRIPTION
## Add missing `form-check-label` CSS class for Bootstrap 4

E.g. with Laravel:

```blade
{!! Former::open()->method('GET') !!}
    {!! Former::checkbox('test')->text('Test checkbox') !!}
{!! Former::close() !!}
```

Render:
```html
<div class="form-check">
  <input class="form-check-input" id="test" type="checkbox" name="test" value="1">
  <label for="test" class="form-check-label">Test checkbox</label>
</div>
```

References:
- https://github.com/formers/former/issues/581
- https://github.com/formers/former/pull/590

---------------
## Fix invalid feedback visibility of checkboxes and radios for Bootstrap 4
E.g. with Laravel:
```blade
@php
    $validator = Validator::make(request()->all(), [
        'failed_checkbox' => 'required',
        'failed_radio' => 'required',
        'failed_inline_checkbox' => 'required',
        'failed_inline_radio' => 'required',
        'failed_checkboxes' => 'required',
        'failed_inline_checkboxes' => 'required',
    ]);

    $validator->fails();
    Former::withErrors($validator);
@endphp

{!! Former::open()->method('GET') !!}
    {!! Former::checkbox('failed_checkbox')->text('Failed checkbox') !!}
    {!! Former::radio('failed_radio')->text('Failed radio') !!}
    {!! Former::checkbox('failed_inline_checkbox')->text('Failed inline checkbox')->inline() !!}
    {!! Former::radio('failed_inline_radio')->text('Failed inline radio')->inline() !!}
    {!! Former::checkboxes('failed_checkboxes')->checkboxes('first', 'second', 'third', 'fourth') !!}
    {!! Former::checkboxes('failed_inline_checkboxes')->checkboxes('first', 'second', 'third', 'fourth')->inline() !!}
{!! Former::close() !!}
```

And here the result:
![former_checkables_invalid_feedback_bs4](https://user-images.githubusercontent.com/5038872/103368871-005e6400-4ac9-11eb-803b-43e6072da8f9.png)

Reference:
https://github.com/formers/former/issues/581#issuecomment-469710643