### PR TITLE
Fix Former::plaintext() with Bootstrap 4

### DIFF
--- a/src/Former/Framework/TwitterBootstrap4.php
+++ b/src/Former/Framework/TwitterBootstrap4.php
@@ -295,7 +295,7 @@ class TwitterBootstrap4 extends Framework implements FrameworkInterface
 	 */
 	public function getPlainTextClasses()
 	{
-		return 'form-control-static';
+		return 'form-control-plaintext';
 	}
 
 	/**

--- a/tests/Fields/PlainTextTest.php
+++ b/tests/Fields/PlainTextTest.php
@@ -152,7 +152,7 @@ class PlainTextTest extends FormerTests
 	 */
 	protected function formStaticGroupForBS4(
 		$input = '<div class="form-control-plaintext" id="foo">bar</div>',
-		$label = '<label for="" class="control-label col-lg-2 col-sm-4">Foo</label>'
+		$label = '<label for="" class="col-form-label col-lg-2 col-sm-4">Foo</label>'
 	) {
 		return $this->formGroupWithBS4($input, $label);
 	}

--- a/tests/Fields/PlainTextTest.php
+++ b/tests/Fields/PlainTextTest.php
@@ -28,7 +28,7 @@ class PlainTextTest extends FormerTests
 	 *
 	 * @return array
 	 */
-	public function matchPlainLabelWithBS3()
+	public function matchPlainLabelWithBS()
 	{
 		return array(
 			'tag' => 'label',
@@ -71,6 +71,22 @@ class PlainTextTest extends FormerTests
 		);
 	}
 
+	/**
+	 * Matches an plain text input as a p tag
+	 *
+	 * @return array
+	 */
+	public function matchPlainTextInputWithBS4()
+ 	{
+ 		return array(
+ 			'tag'        => 'div',
+ 			'content'    => 'bar',
+ 			'attributes' => array(
+ 				'class' => 'form-control-plaintext',
+ 			),
+ 		);
+ 	}
+
 	////////////////////////////////////////////////////////////////////
 	////////////////////////////// ASSERTIONS //////////////////////////
 	////////////////////////////////////////////////////////////////////
@@ -88,6 +104,21 @@ class PlainTextTest extends FormerTests
 		$label = '<label for="" class="control-label col-lg-2 col-sm-4">Foo</label>'
 	) {
 		return $this->formGroup($input, $label);
+	}
+
+	/**
+	 * Matches a Form Static Group
+	 *
+	 * @param  string $input
+	 * @param  string $label
+	 *
+	 * @return boolean
+	 */
+	protected function formStaticGroupForBS4(
+		$input = '<div class="form-control-plaintext" id="foo">bar</div>',
+		$label = '<label for="" class="control-label col-lg-2 col-sm-4">Foo</label>'
+	) {
+		return $this->formGroupWithBS4($input, $label);
 	}
 
 	////////////////////////////////////////////////////////////////////
@@ -115,10 +146,22 @@ class PlainTextTest extends FormerTests
 		$this->former->framework('TwitterBootstrap3');
 		$input = $this->former->plaintext('foo')->value('bar')->__toString();
 
-		$this->assertHTML($this->matchPlainLabelWithBS3(), $input);
+		$this->assertHTML($this->matchPlainLabelWithBS(), $input);
 		$this->assertHTML($this->matchPlainTextInput(), $input);
 
 		$matcher = $this->formStaticGroup();
+		$this->assertEquals($matcher, $input);
+	}
+
+	public function testCanCreatePlainTextFieldsWithBS4()
+	{
+		$this->former->framework('TwitterBootstrap4');
+		$input = $this->former->plaintext('foo')->value('bar')->__toString();
+
+		$this->assertHTML($this->matchPlainLabelWithBS(), $input);
+		$this->assertHTML($this->matchPlainTextInputWithBS4(), $input);
+
+		$matcher = $this->formStaticGroupForBS4();
 		$this->assertEquals($matcher, $input);
 	}
 }

--- a/tests/TestCases/FormerTests.php
+++ b/tests/TestCases/FormerTests.php
@@ -303,6 +303,21 @@ abstract class FormerTests extends ContainerTestCase
 	}
 
 	/**
+	 * Matches a Form Group
+	 *
+	 * @param  string $input
+	 * @param  string $label
+	 *
+	 * @return boolean
+	 */
+	protected function formGroupWithBS4(
+		$input = '<input type="text" name="foo" id="foo">',
+		$label = '<label for="foo" class="control-label col-lg-2 col-sm-4">Foo</label>'
+	) {
+		return '<div class="form-group row">'.$label.'<div class="col-lg-10 col-sm-8">'.$input.'</div></div>';
+	}
+
+	/**
 	 * Matches a required Control Group
 	 *
 	 * @param  string $input

--- a/tests/TestCases/FormerTests.php
+++ b/tests/TestCases/FormerTests.php
@@ -367,7 +367,7 @@ abstract class FormerTests extends ContainerTestCase
     {
         $dom     = Xml::load($actual, $ishtml);
         $tags    = self::findNodes($dom, $matcher, $ishtml);
-        $matched = count($tags) > 0 && $tags[0] instanceof DOMNode;
+        $matched = $tags !== false && count($tags) > 0 && $tags[0] instanceof DOMNode;
 
         self::assertTrue($matched, $message);
     }

--- a/tests/TestCases/FormerTests.php
+++ b/tests/TestCases/FormerTests.php
@@ -312,7 +312,7 @@ abstract class FormerTests extends ContainerTestCase
 	 */
 	protected function formGroupWithBS4(
 		$input = '<input type="text" name="foo" id="foo">',
-		$label = '<label for="foo" class="control-label col-lg-2 col-sm-4">Foo</label>'
+		$label = '<label for="foo" class="col-form-label col-lg-2 col-sm-4">Foo</label>'
 	) {
 		return '<div class="form-group row">'.$label.'<div class="col-lg-10 col-sm-8">'.$input.'</div></div>';
 	}


### PR DESCRIPTION
Replace `form-control-static` CSS class with `form-control-plaintext`

Usage with Laravel:
```blade
{!! Former::open()->method('GET') !!}
  {!! Former::plaintext('test_static')->value('Plain Text') !!}
{!! Former::close() !!}
```

Reference:
https://getbootstrap.com/docs/4.5/components/forms/#readonly-plain-text