### PR TITLE
Fix vertical alignment for labels in Bootstrap 4

### DIFF
--- a/src/Former/Form/Group.php
+++ b/src/Former/Form/Group.php
@@ -409,20 +409,27 @@ class Group extends Tag
 	 *
 	 * @return string        A <label> tag
 	 */
-	protected function getLabel($field = null)
-	{
-		// Don't create a label if none exist
-		if (!$field or !$this->label) {
-			return null;
-		}
+	 protected function getLabel($field = null)
+ 	{
+ 		// Don't create a label if none exist
+ 		if (!$field or !$this->label) {
+ 			return null;
+ 		}
 
-		// Wrap label in framework classes
-		$this->label->addClass($this->app['former.framework']->getLabelClasses());
-		$this->label = $this->app['former.framework']->createLabelOf($field, $this->label);
-		$this->label = $this->app['former.framework']->wrapLabel($this->label);
+ 		// Wrap label in framework classes
+ 		$labelClasses = $this->app['former.framework']->getLabelClasses();
+ 		if ($field->isCheckable() &&
+ 			$this->app['former']->framework() == 'TwitterBootstrap4' &&
+ 			$this->app['former.form']->isOfType('horizontal')
+ 		) {
+ 			$labelClasses = array_merge($labelClasses, array('pt-0'));
+ 		}
+ 		$this->label->addClass($labelClasses);
+ 		$this->label = $this->app['former.framework']->createLabelOf($field, $this->label);
+ 		$this->label = $this->app['former.framework']->wrapLabel($this->label);
 
-		return $this->label;
-	}
+ 		return $this->label;
+ 	}
 
 	/**
 	 * Prints out the current help

--- a/src/Former/Framework/TwitterBootstrap4.php
+++ b/src/Former/Framework/TwitterBootstrap4.php
@@ -270,11 +270,11 @@ class TwitterBootstrap4 extends Framework implements FrameworkInterface
 	public function getLabelClasses()
 	{
 		if ($this->app['former.form']->isOfType('horizontal')) {
-			return array('control-label', $this->labelWidth);
+			return array('col-form-label', $this->labelWidth);
 		} elseif ($this->app['former.form']->isOfType('inline')) {
 			return array('sr-only');
 		} else {
-			return array('control-label');
+			return array('col-form-label');
 		}
 	}
 

--- a/tests/Framework/TwitterBootstrap4Test.php
+++ b/tests/Framework/TwitterBootstrap4Test.php
@@ -44,7 +44,7 @@ class TwitterBootstrap4Test extends FormerTests
 		$field = $this->former->text('foo')->__toString();
 		$this->former->close();
 
-		$match = $this->vmatch('<label for="foo" class="control-label">Foo</label>',
+		$match = $this->vmatch('<label for="foo" class="col-form-label">Foo</label>',
 			'<input class="form-control" id="foo" type="text" name="foo">');
 
 		$this->assertEquals($match, $field);
@@ -53,7 +53,7 @@ class TwitterBootstrap4Test extends FormerTests
 	public function testHorizontalFormWithDefaultLabelWidths()
 	{
 		$field = $this->former->text('foo')->__toString();
-		$match = $this->hmatch('<label for="foo" class="control-label col-lg-2 col-sm-4">Foo</label>',
+		$match = $this->hmatch('<label for="foo" class="col-form-label col-lg-2 col-sm-4">Foo</label>',
 			'<input class="form-control" id="foo" type="text" name="foo">');
 
 		$this->assertEquals($match, $field);
@@ -63,7 +63,7 @@ class TwitterBootstrap4Test extends FormerTests
 	{
 		$this->former->open_vertical();
 		$icon  = $this->former->text('foo')->prependIcon('thumbs-up')->__toString();
-		$match = $this->vmatch('<label for="foo" class="control-label">Foo</label>',
+		$match = $this->vmatch('<label for="foo" class="col-form-label">Foo</label>',
 			'<div class="input-group">'.
 			'<span class="input-group-addon"><i class="fa fa-thumbs-up"></i></span>'.
 			'<input class="form-control" id="foo" type="text" name="foo">'.
@@ -76,7 +76,7 @@ class TwitterBootstrap4Test extends FormerTests
 	{
 		$this->former->open_vertical();
 		$icon  = $this->former->text('foo')->appendIcon('thumbs-up')->__toString();
-		$match = $this->vmatch('<label for="foo" class="control-label">Foo</label>',
+		$match = $this->vmatch('<label for="foo" class="col-form-label">Foo</label>',
 			'<div class="input-group">'.
 			'<input class="form-control" id="foo" type="text" name="foo">'.
 			'<span class="input-group-addon"><i class="fa fa-thumbs-up"></i></span>'.
@@ -88,7 +88,7 @@ class TwitterBootstrap4Test extends FormerTests
 	{
 		$this->former->open_vertical();
 		$field = $this->former->text('foo')->__toString();
-		$match = $this->vmatch('<label for="foo" class="control-label">Foo</label>',
+		$match = $this->vmatch('<label for="foo" class="col-form-label">Foo</label>',
 			'<input class="form-control" id="foo" type="text" name="foo">');
 
 		$this->assertEquals($match, $field);
@@ -139,7 +139,7 @@ class TwitterBootstrap4Test extends FormerTests
 		$required = $this->former->text('required')->__toString();
 		$matcher  =
 			'<div class="form-group is-invalid">'.
-			'<label for="required" class="control-label">Required</label>'.
+			'<label for="required" class="col-form-label">Required</label>'.
 			'<input class="form-control is-invalid" id="required" type="text" name="required">'.
 			'<div class="invalid-feedback">The required field is required.</div>'.
 			'</div>';
@@ -172,7 +172,7 @@ class TwitterBootstrap4Test extends FormerTests
 		$field = $this->former->lg_text('foo')->__toString();
 		$match =
 			'<div class="form-group">'.
-			'<label for="foo" class="control-label">Foo</label>'.
+			'<label for="foo" class="col-form-label">Foo</label>'.
 			'<input class="input-lg form-control" id="foo" type="text" name="foo">'.
 			'</div>';
 		$this->assertEquals($match, $field);
@@ -181,7 +181,7 @@ class TwitterBootstrap4Test extends FormerTests
 		$field = $this->former->sm_select('foo')->__toString();
 		$match =
 			'<div class="form-group">'.
-			'<label for="foo" class="control-label">Foo</label>'.
+			'<label for="foo" class="col-form-label">Foo</label>'.
 			'<select class="input-sm form-control" id="foo" name="foo"></select>'.
 			'</div>';
 		$this->assertEquals($match, $field);


### PR DESCRIPTION
- Replace `control-label` CSS class by `col-form-label`
- Add an additional `pt-0` class for checkable fields in horizontal forms.

Reference: https://getbootstrap.com/docs/4.5/components/forms/#horizontal-form