### PR TITLE
Add CSS class to the label of a group

### DIFF
--- a/src/Former/Form/Group.php
+++ b/src/Former/Form/Group.php
@@ -209,6 +209,23 @@ class Group extends Tag
 	}
 
 	/**
+	 * Set a class on the Label
+	 *
+	 * @param string $class The class to add on the Label
+	 */
+	public function addLabelClass($class)
+	{
+		// Don't add a label class if it isn't an Element instance
+		if (!$this->label instanceof Element) {
+			return $this;
+		}
+
+		$this->label->addClass($class);
+
+		return $this;
+	}
+
+	/**
 	 * Adds a label to the group
 	 *
 	 * @param  string $label A label

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -304,6 +304,15 @@ class GroupTest extends FormerTests
 		$this->assertEquals($matcher, $control);
 	}
 
+	public function testCanAddClassToLabel()
+	{
+		$control = $this->former->text('foo')->addLabelClass('foo-label')->__toString();
+		$matcher = $this->createMatcher();
+		$matcher = str_replace('control-label"', 'foo-label control-label"', $matcher);
+
+		$this->assertEquals($matcher, $control);
+	}
+
 	public function testCanRecognizeGroupValidationErrors()
 	{
 		$this->mockSession(array('foo' => 'bar', 'bar' => 'baz'));


### PR DESCRIPTION
Usage with Laravel and Bootstrap 4:
```blade
{!! Former::open()->method('GET') !!}
    {!! Former::text('foo')->addLabelClass('bar') !!}
{!! Former::close() !!}
```

Will produce:
```html
<form accept-charset="utf-8" class="form-horizontal" method="GET">
  <div class="form-group row">
    <label for="foo" class="bar col-form-label col-lg-2 col-sm-4">Foo</label>
    <div class="col-lg-10 col-sm-8">
      <input class="form-control" id="foo" type="text" name="foo">
    </div>
  </div>
</form>
```