### PR TITLE
Escape HTML value of 'plaintext' field by default

### DIFF
--- a/src/Former/Form/Fields/Plaintext.php
+++ b/src/Former/Form/Fields/Plaintext.php
@@ -2,6 +2,7 @@
 namespace Former\Form\Fields;
 
 use Former\Traits\Field;
+use Illuminate\Support\HtmlString;
 
 /**
  * Renders Plain Text Control
@@ -21,7 +22,16 @@ class Plaintext extends Field
 	{
 		$this->addClass($this->app['former.framework']->getPlainTextClasses());
 		$this->setId();
+		$this->escapeValue();
 
 		return $this->app['former.framework']->createPlainTextField($this);
+	}
+
+	protected function escapeValue()
+	{
+		$valueToEscape = $this->getValue();
+		$value = is_string($valueToEscape) || $valueToEscape instanceof HtmlString ? e($valueToEscape) : $valueToEscape;
+
+		return $this->forceValue($value);
 	}
 }

--- a/tests/Fields/PlainTextTest.php
+++ b/tests/Fields/PlainTextTest.php
@@ -2,6 +2,7 @@
 namespace Former\Fields;
 
 use Former\TestCases\FormerTests;
+use Illuminate\Support\HtmlString;
 
 class PlainTextTest extends FormerTests
 {
@@ -56,7 +57,7 @@ class PlainTextTest extends FormerTests
 	}
 
 	/**
-	 * Matches an plain text input as a p tag
+	 * Matches an plain text input as a div tag
 	 *
 	 * @return array
 	 */
@@ -65,6 +66,41 @@ class PlainTextTest extends FormerTests
 		return array(
 			'tag'        => 'div',
 			'content'    => 'bar',
+			'attributes' => array(
+				'class' => 'form-control-static',
+			),
+		);
+	}
+
+	/**
+	 * Matches an plain text input as a div tag
+	 *
+	 * @return array
+	 */
+	public function matchPlainTextInputWithHtmlValueEscaped()
+	{
+		return array(
+			'tag'        => 'div',
+			'content'    => '<script>alert(1);</script>',
+			'attributes' => array(
+				'class' => 'form-control-static',
+			),
+		);
+	}
+
+	/**
+	 * Matches an plain text input as a div tag
+	 *
+	 * @return array
+	 */
+	public function matchPlainTextInputWithHtmlValue()
+	{
+		return array(
+			'tag'        => 'div',
+			'child'      => array(
+				'tag'        => 'strong',
+				'content'    => 'bar',
+			),
 			'attributes' => array(
 				'class' => 'form-control-static',
 			),
@@ -85,6 +121,36 @@ class PlainTextTest extends FormerTests
 	 */
 	protected function formStaticGroup(
 		$input = '<div class="form-control-static" id="foo">bar</div>',
+		$label = '<label for="" class="control-label col-lg-2 col-sm-4">Foo</label>'
+	) {
+		return $this->formGroup($input, $label);
+	}
+
+	/**
+	 * Matches a Form Static Group with HTML value escaped
+	 *
+	 * @param  string $input
+	 * @param  string $label
+	 *
+	 * @return boolean
+	 */
+	protected function formStaticGroupWithHtmlValueEscaped(
+		$input = '<div class="form-control-static" id="foo">&lt;script&gt;alert(1);&lt;/script&gt;</div>',
+		$label = '<label for="" class="control-label col-lg-2 col-sm-4">Foo</label>'
+	) {
+		return $this->formGroup($input, $label);
+	}
+
+	/**
+	 * Matches a Form Static Group with HTML value
+	 *
+	 * @param  string $input
+	 * @param  string $label
+	 *
+	 * @return boolean
+	 */
+	protected function formStaticGroupWithHtmlValue(
+		$input = '<div class="form-control-static" id="foo"><strong>bar</strong></div>',
 		$label = '<label for="" class="control-label col-lg-2 col-sm-4">Foo</label>'
 	) {
 		return $this->formGroup($input, $label);
@@ -119,6 +185,32 @@ class PlainTextTest extends FormerTests
 		$this->assertHTML($this->matchPlainTextInput(), $input);
 
 		$matcher = $this->formStaticGroup();
+		$this->assertEquals($matcher, $input);
+	}
+
+	public function testCanCreatePlainTextFieldsWithHtmlValueEscaped()
+	{
+		$this->former->framework('TwitterBootstrap3');
+		$htmlValue = '<script>alert(1);</script>';
+		$input = $this->former->plaintext('foo')->value($htmlValue)->__toString();
+
+		$this->assertHTML($this->matchPlainLabelWithBS3(), $input);
+		$this->assertHTML($this->matchPlainTextInputWithHtmlValueEscaped(), $input);
+
+		$matcher = $this->formStaticGroupWithHtmlValueEscaped();
+		$this->assertEquals($matcher, $input);
+	}
+
+	public function testCanCreatePlainTextFieldsWithHtmlValue()
+	{
+		$this->former->framework('TwitterBootstrap3');
+		$htmlValue = new HtmlString('<strong>bar</strong>');
+		$input = $this->former->plaintext('foo')->value($htmlValue)->__toString();
+
+		$this->assertHTML($this->matchPlainLabelWithBS3(), $input);
+		$this->assertHTML($this->matchPlainTextInputWithHtmlValue(), $input);
+
+		$matcher = $this->formStaticGroupWithHtmlValue();
 		$this->assertEquals($matcher, $input);
 	}
 }

--- a/tests/TestCases/FormerTests.php
+++ b/tests/TestCases/FormerTests.php
@@ -367,7 +367,7 @@ abstract class FormerTests extends ContainerTestCase
     {
         $dom     = Xml::load($actual, $ishtml);
         $tags    = self::findNodes($dom, $matcher, $ishtml);
-        $matched = count($tags) > 0 && $tags[0] instanceof DOMNode;
+        $matched = $tags !== false && count($tags) > 0 && $tags[0] instanceof DOMNode;
 
         self::assertTrue($matched, $message);
     }


### PR DESCRIPTION
## Basic usage with Laravel and Bootstrap 4:
```blade
{!! Former::open()->method('GET') !!}
    {!! Former::plaintext('test_static_escaped')->value(
          '<b>Text</b>'
        )
    !!}
    {!! Former::plaintext('test_static')->value(
          new Illuminate\Support\HtmlString('<b>Text</b>')
        )
    !!}
{!! Former::close() !!}
```

Will produce:
```html
<form accept-charset="utf-8" class="form-horizontal" method="GET">
  <div class="form-group row">
    <label for="" class="col-form-label col-lg-2 col-sm-4">
      Test static escaped
    </label>
    <div class="col-lg-10 col-sm-8">
      <div class="form-control-plaintext" id="test_static_escaped">
        &lt;b&gt;Text&lt;/b&gt;
      </div>
    </div>
  </div>
  <div class="form-group row">
    <label for="" class="col-form-label col-lg-2 col-sm-4">
      Test static
    </label>
    <div class="col-lg-10 col-sm-8">
      <div class="form-control-plaintext" id="test_static">
        <b>Text</b>
      </div>
    </div>
  </div>
</form>
```

## Advanced usage with Laravel and Bootstrap 4
If you populate your form, you should use the `forceValue()` method instead of the `value()` method, like this:
```blade
@php
    $data = ['text' => '<b>rich text</b>'];
    Former::populate($data);
@endphp
{!! Former::open()->method('GET') !!}
    {!! Former::plaintext('text') !!}
    {!! Former::plaintext('text')
            ->forceValue(
                new Illuminate\Support\HtmlString($data['text'])
        )
    !!}
{!! Former::close() !!}
```

Will produce:
```html
<form accept-charset="utf-8" class="form-horizontal" method="GET">
  <div class="form-group row">
    <label for="" class="col-form-label col-lg-2 col-sm-4">Text</label>
    <div class="col-lg-10 col-sm-8">
      <div class="form-control-plaintext" id="text">&lt;b&gt;rich text&lt;/b&gt;</div>
    </div>
  </div>
  <div class="form-group row">
    <label for="" class="col-form-label col-lg-2 col-sm-4">Text</label>
    <div class="col-lg-10 col-sm-8">
      <div class="form-control-plaintext" id="text-2"><b>rich text</b></div>
    </div>
  </div>
</form>
```