### PR TITLE
Allow installation on Laravel 10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,17 +8,17 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        php: [ "8.1", "8.0", "7.4", "7.3", "7.2" ]
+        php: [ "8.2", "8.1", "8.0", "7.4", "7.3", "7.2" ]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.composer/cache/files
           key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
   ],
   "require": {
     "php": "^7.2|^8.0",
-    "anahkiasen/html-object": "~1.4",
     "illuminate/config": "^5.1.3|^6.0|^7.0|^8.0|^9.0|^10.0",
     "illuminate/container": "^5.1.3|^6.0|^7.0|^8.0|^9.0|^10.0",
     "illuminate/contracts": "^5.1.3|^6.0|^7.0|^8.0|^9.0|^10.0",
@@ -25,7 +24,8 @@
     "illuminate/routing": "^5.1.3|^6.0|^7.0|^8.0|^9.0|^10.0",
     "illuminate/session": "^5.1.3|^6.0|^7.0|^8.0|^9.0|^10.0",
     "illuminate/translation": "^5.1.3|^6.0|^7.0|^8.0|^9.0|^10.0",
-    "illuminate/support": "^5.1.3|^6.0|^7.0|^8.0|^9.0|^10.0"
+    "illuminate/support": "^5.1.3|^6.0|^7.0|^8.0|^9.0|^10.0",
+    "kylekatarnls/html-object": "^1.5"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5",

--- a/composer.json
+++ b/composer.json
@@ -18,19 +18,19 @@
   "require": {
     "php": "^7.2|^8.0",
     "anahkiasen/html-object": "~1.4",
-    "illuminate/config": "^5.1.3|^6.0|^7.0|^8.0|^9.0",
-    "illuminate/container": "^5.1.3|^6.0|^7.0|^8.0|^9.0",
-    "illuminate/contracts": "^5.1.3|^6.0|^7.0|^8.0|^9.0",
-    "illuminate/http": "^5.1.3|^6.0|^7.0|^8.0|^9.0",
-    "illuminate/routing": "^5.1.3|^6.0|^7.0|^8.0|^9.0",
-    "illuminate/session": "^5.1.3|^6.0|^7.0|^8.0|^9.0",
-    "illuminate/translation": "^5.1.3|^6.0|^7.0|^8.0|^9.0",
-    "illuminate/support": "^5.1.3|^6.0|^7.0|^8.0|^9.0"
+    "illuminate/config": "^5.1.3|^6.0|^7.0|^8.0|^9.0|^10.0",
+    "illuminate/container": "^5.1.3|^6.0|^7.0|^8.0|^9.0|^10.0",
+    "illuminate/contracts": "^5.1.3|^6.0|^7.0|^8.0|^9.0|^10.0",
+    "illuminate/http": "^5.1.3|^6.0|^7.0|^8.0|^9.0|^10.0",
+    "illuminate/routing": "^5.1.3|^6.0|^7.0|^8.0|^9.0|^10.0",
+    "illuminate/session": "^5.1.3|^6.0|^7.0|^8.0|^9.0|^10.0",
+    "illuminate/translation": "^5.1.3|^6.0|^7.0|^8.0|^9.0|^10.0",
+    "illuminate/support": "^5.1.3|^6.0|^7.0|^8.0|^9.0|^10.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5",
     "mockery/mockery": "^1.3",
-    "illuminate/database": "^5.1.3|^6.0|^7.0|^8.0|^9.0"
+    "illuminate/database": "^5.1.3|^6.0|^7.0|^8.0|^9.0|^10.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Former/Form/Elements.php
+++ b/src/Former/Form/Elements.php
@@ -62,7 +62,7 @@ class Elements
 	{
 		if (!$label instanceof Htmlable) {
 			$oldLabel = (string) $label;
-			$label    = Helpers::translate($oldLabel);
+			$label    = Helpers::translate($oldLabel, '');
 
 			// If there was no change to the label,
 			// then a Laravel translation did not occur
@@ -70,7 +70,7 @@ class Elements
 				$label = str_replace('_', ' ', $label);
 			}
 		} else {
-			$label = (string) $label->toHtml();
+			$label = $label->toHtml();
 		}
 
 		$attributes['for']             = $for;

--- a/src/Former/Form/Fields/Choice.php
+++ b/src/Former/Form/Fields/Choice.php
@@ -191,7 +191,7 @@ class Choice extends Field
 
 	public function getCheckables($choiceType)
 	{
-		if (!(is_array($this->value) || $this->value instanceof \ArrayAccess)) {
+		if ($this->value !== null && !(is_array($this->value) || $this->value instanceof \ArrayAccess)) {
 			$this->value = explode(',', $this->value);
 		}
 
@@ -233,7 +233,7 @@ class Choice extends Field
 			}
 
 			// If inline items, add class
-			$isInline = $this->inline ? ' '.$this->app['former.framework']->getInlineLabelClass($this) : null;
+			$isInline = $this->inline ? ' '.$this->app['former.framework']->getInlineLabelClass($this) : '';
 
 			// In Bootsrap 3, don't append the the checkable type (radio/checkbox) as a class if
 			// rendering inline.

--- a/src/Former/Form/Group.php
+++ b/src/Former/Form/Group.php
@@ -440,7 +440,7 @@ class Group extends Tag
 			$inline = $this->app['former.framework']->createValidationError($errors);
 		}
 
-		return join(null, array($inline, $block));
+		return implode('', array($inline, $block));
 	}
 
 	/**

--- a/src/Former/Former.php
+++ b/src/Former/Former.php
@@ -250,7 +250,7 @@ class Former
 	 */
 	public function getPost($name, $fallback = null)
 	{
-		$name     = str_replace(array('[', ']'), array('.', ''), $name);
+		$name     = str_replace(array('[', ']'), array('.', ''), $name ?? '');
 		$name     = trim($name, '.');
 		$oldValue = $this->app['request']->old($name, $fallback);
 

--- a/src/Former/Framework/Nude.php
+++ b/src/Former/Framework/Nude.php
@@ -161,9 +161,9 @@ class Nude extends Framework implements FrameworkInterface
 	public function prependAppend($field, $prepend, $append)
 	{
 		$return = '<div>';
-		$return .= join(null, $prepend);
+		$return .= implode('', $prepend);
 		$return .= $field->render();
-		$return .= join(null, $append);
+		$return .= implode('', $append);
 		$return .= '</div>';
 
 		return $return;

--- a/src/Former/Framework/TwitterBootstrap.php
+++ b/src/Former/Framework/TwitterBootstrap.php
@@ -353,9 +353,9 @@ class TwitterBootstrap extends Framework implements FrameworkInterface
 		}
 
 		$return = '<div class="'.join(' ', $class).'">';
-		$return .= join(null, $prepend);
+		$return .= implode('', $prepend);
 		$return .= $field->render();
-		$return .= join(null, $append);
+		$return .= implode('', $append);
 		$return .= '</div>';
 
 		return $return;

--- a/src/Former/Framework/TwitterBootstrap3.php
+++ b/src/Former/Framework/TwitterBootstrap3.php
@@ -406,9 +406,9 @@ class TwitterBootstrap3 extends Framework implements FrameworkInterface
 	public function prependAppend($field, $prepend, $append)
 	{
 		$return = '<div class="input-group">';
-		$return .= join(null, $prepend);
+		$return .= implode('', $prepend);
 		$return .= $field->render();
-		$return .= join(null, $append);
+		$return .= implode('', $append);
 		$return .= '</div>';
 
 		return $return;

--- a/src/Former/Framework/TwitterBootstrap4.php
+++ b/src/Former/Framework/TwitterBootstrap4.php
@@ -430,9 +430,9 @@ class TwitterBootstrap4 extends Framework implements FrameworkInterface
 	public function prependAppend($field, $prepend, $append)
 	{
 		$return = '<div class="input-group">';
-		$return .= join(null, $prepend);
+		$return .= implode('', $prepend);
 		$return .= $field->render();
-		$return .= join(null, $append);
+		$return .= implode('', $append);
 		$return .= '</div>';
 
 		return $return;

--- a/src/Former/Helpers.php
+++ b/src/Former/Helpers.php
@@ -54,7 +54,7 @@ class Helpers
 	{
 		// If nothing was given, return nothing, bitch
 		if (!$key) {
-			return null;
+			return $fallback;
 		}
 
 		// If no fallback, use the key

--- a/src/Former/Traits/Checkable.php
+++ b/src/Former/Traits/Checkable.php
@@ -293,8 +293,8 @@ abstract class Checkable extends Field
 
 			// Grouped fields
 			if ($this->isGrouped()) {
-				$attributes['id'] = str_replace('[]', null, $fallback);
-				$fallback         = str_replace('[]', null, $this->name).'[]';
+				$attributes['id'] = str_replace('[]', '', $fallback);
+				$fallback         = str_replace('[]', '', $this->name).'[]';
 			}
 
 			// If we haven't any name defined for the checkable, try to compute some
@@ -350,7 +350,7 @@ abstract class Checkable extends Field
 		}
 
 		// If inline items, add class
-		$isInline = $this->inline ? ' '.$this->app['former.framework']->getInlineLabelClass($this) : null;
+		$isInline = $this->inline ? ' '.$this->app['former.framework']->getInlineLabelClass($this) : '';
 
 		// In Bootsrap 3 or 4, don't append the the checkable type (radio/checkbox) as a class if
 		// rendering inline.

--- a/tests/Dummy/DummyButton.php
+++ b/tests/Dummy/DummyButton.php
@@ -3,6 +3,8 @@ namespace Former\Dummy;
 
 class DummyButton
 {
+    private $text;
+
 	public function __construct($text)
 	{
 		$this->text = $text;

--- a/tests/Fields/RadioTest.php
+++ b/tests/Fields/RadioTest.php
@@ -34,7 +34,7 @@ class RadioTest extends FormerTests
 			'disabled' => $disabled === 'disabled' ? 'disabled' : null,
 			'id'       => $name,
 			'type'     => 'radio',
-			'name'     => preg_replace('/[0-9]/', null, $name),
+			'name'     => preg_replace('/[0-9]/', '', $name),
 			'checked'  => 'checked',
 			'value'    => $value,
 		);

--- a/tests/Framework/TwitterBootstrapTest.php
+++ b/tests/Framework/TwitterBootstrapTest.php
@@ -44,9 +44,9 @@ class TwitterBootstrapTest extends FormerTests
 			'<label for="foo" class="control-label">Foo</label>'.
 			'<div class="controls">'.
 			'<div class="'.implode(' ', $class).'">'.
-			join(null, $prepend).
+			implode('', $prepend).
 			'<input id="foo" type="text" name="foo">'.
-			join(null, $append).
+			implode('', $append).
 			'</div>'.
 			'</div>'.
 			'</div>';

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -78,9 +78,9 @@ class GroupTest extends FormerTests
 			'<label for="foo" class="control-label">Foo</label>'.
 			'<div class="controls">'.
 			'<div class="'.implode(' ', $class).'">'.
-			join(null, $prepend).
+			implode('', $prepend).
 			'<input id="foo" type="text" name="foo">'.
-			join(null, $append).
+			implode('', $append).
 			'</div>'.
 			'</div>'.
 			'</div>';

--- a/tests/TestCases/FormerTests.php
+++ b/tests/TestCases/FormerTests.php
@@ -128,7 +128,7 @@ abstract class FormerTests extends ContainerTestCase
 	 */
 	protected function matchLabel($name = 'foo', $field = 'foo', $required = false)
 	{
-		$text = str_replace('[]', null, $name);
+		$text = str_replace('[]', '', $name);
 		if ($required) {
 			$text .= '*';
 		}
@@ -634,7 +634,7 @@ abstract class FormerTests extends ContainerTestCase
 
                 foreach ($options['attributes'] as $name => $value) {
                     // match by regexp if like "regexp:/foo/i"
-                    if (preg_match('/^regexp\s*:\s*(.*)/i', $value, $matches)) {
+                    if (!empty($value) && preg_match('/^regexp\s*:\s*(.*)/i', $value, $matches)) {
                         if (!preg_match($matches[1], $node->getAttribute($name))) {
                             $invalid = true;
                         }


### PR DESCRIPTION
- [x] Allow installing on Laravel 10 (not tested further than the test suite, so might have some rough edges)
- [x] Cleanup all PHP 8+ deprecations caught by our own testsuite
- [x] Add tests on PHP 8.2 to GitHub actions
- [x] ~~Requires two upstream PRs merged and released to solve all deprecation messages caught by the test suite (but not a blocker for a release)~~
	- [x] ~~Anahkiasen/html-object#35~~
	- [x] ~~Anahkiasen/html-object#36~~
- [x] Replace `anahkiasen/html-object` with fork `kylekatarnls/html-object`, this one is drop in replacement with PHP 8(.2) fixes integrated