### PR TITLE
Fix incorrect option selection logic and improve data binding for Select and Checkable fields

### DIFF
--- a/src/Former/Form/Fields/Select.php
+++ b/src/Former/Form/Fields/Select.php
@@ -95,6 +95,8 @@ class Select extends Field
 			$this->value = (array) $this->value;
 		}
 
+        $this->clearSelected();
+
 		// Mark selected values as selected
 		if ($this->hasChildren() and !empty($this->value)) {
 			foreach ($this->value as $value) {
@@ -131,9 +133,9 @@ class Select extends Field
 		}
 
 		foreach ($parent->getChildren() as $child) {
-			// Search by value
+            $optionValue = $child->getAttribute('value');
 
-			if ($child->getAttribute('value') === $value || is_numeric($value) && $child->getAttribute('value') === (int)$value ) {
+            if ($optionValue === $value || (is_numeric($value) && is_numeric($optionValue) && (int)$optionValue === (int)$value) ) {
 				$child->selected('selected');
 			}
 
@@ -239,7 +241,11 @@ class Select extends Field
 		if (is_array($text)) {
 			$this->children[$childrenKey] = Element::create('optgroup')->label($value);
 			foreach ($text as $key => $value) {
-				$option = Element::create('option', $value)->setAttribute('value', $key);
+                if (is_array($value)) {
+                    $option = Element::create('option', $key)->setAttributes($value);
+                } else {
+                    $option = Element::create('option', $value)->setAttribute('value', $key);
+                }
 				$this->children[$childrenKey]->nest($option);
 			}
 			// Else if it's a simple option
@@ -253,6 +259,28 @@ class Select extends Field
 
 		return $this;
 	}
+
+    /**
+     * Clear selected attribute for select options
+     *
+     * @param Element $parent
+     *
+     * @return void
+     */
+    public function clearSelected($parent = null) {
+        // If no parent element defined, use direct children
+        if (!$parent) {
+            $parent = $this;
+        }
+
+        foreach ($parent->getChildren() as $child) {
+            $child->removeAttribute('selected');
+
+            if ($child->hasChildren()) {
+                $this->clearSelected($child);
+            }
+        }
+    }
 
 	/**
 	 * Use the results from a Fluent/Eloquent query as options

--- a/src/Former/Form/Fields/Select.php
+++ b/src/Former/Form/Fields/Select.php
@@ -95,7 +95,7 @@ class Select extends Field
 			$this->value = (array) $this->value;
 		}
 
-        $this->clearSelected();
+		$this->clearSelected();
 
 		// Mark selected values as selected
 		if ($this->hasChildren() and !empty($this->value)) {
@@ -133,9 +133,9 @@ class Select extends Field
 		}
 
 		foreach ($parent->getChildren() as $child) {
-            $optionValue = $child->getAttribute('value');
+			$optionValue = $child->getAttribute('value');
 
-            if ($optionValue === $value || (is_numeric($value) && is_numeric($optionValue) && (int)$optionValue === (int)$value) ) {
+			if ($optionValue === $value || (is_numeric($value) && is_numeric($optionValue) && (int)$optionValue === (int)$value)) {
 				$child->selected('selected');
 			}
 
@@ -241,11 +241,11 @@ class Select extends Field
 		if (is_array($text)) {
 			$this->children[$childrenKey] = Element::create('optgroup')->label($value);
 			foreach ($text as $key => $value) {
-                if (is_array($value)) {
-                    $option = Element::create('option', $key)->setAttributes($value);
-                } else {
-                    $option = Element::create('option', $value)->setAttribute('value', $key);
-                }
+				if (is_array($value)) {
+					$option = Element::create('option', $key)->setAttributes($value);
+				} else {
+					$option = Element::create('option', $value)->setAttribute('value', $key);
+				}
 				$this->children[$childrenKey]->nest($option);
 			}
 			// Else if it's a simple option
@@ -260,27 +260,28 @@ class Select extends Field
 		return $this;
 	}
 
-    /**
-     * Clear selected attribute for select options
-     *
-     * @param Element $parent
-     *
-     * @return void
-     */
-    public function clearSelected($parent = null) {
-        // If no parent element defined, use direct children
-        if (!$parent) {
-            $parent = $this;
-        }
+	/**
+	 * Clear selected attribute for select options
+	 *
+	 * @param Element $parent
+	 *
+	 * @return void
+	 */
+	public function clearSelected($parent = null)
+	{
+		// If no parent element defined, use direct children
+		if (!$parent) {
+			$parent = $this;
+		}
 
-        foreach ($parent->getChildren() as $child) {
-            $child->removeAttribute('selected');
+		foreach ($parent->getChildren() as $child) {
+			$child->removeAttribute('selected');
 
-            if ($child->hasChildren()) {
-                $this->clearSelected($child);
-            }
-        }
-    }
+			if ($child->hasChildren()) {
+				$this->clearSelected($child);
+			}
+		}
+	}
 
 	/**
 	 * Use the results from a Fluent/Eloquent query as options

--- a/src/Former/Helpers.php
+++ b/src/Former/Helpers.php
@@ -29,18 +29,22 @@ class Helpers
 	/**
 	 * Encodes HTML
 	 *
-	 * @param string|null $value The string to encode
+	 * @param string|array|null $value The string to encode
 	 *
 	 * @return string
 	 */
-	public static function encode($value)
-	{
-		if ($value === null) {
-			return '';
-		}
+    public static function encode($value)
+    {
+        if ($value === null) {
+            return '';
+        }
 
-		return htmlentities($value, ENT_QUOTES, 'UTF-8', true);
-	}
+        if (is_array($value)) {
+            $value = '';
+        }
+
+        return htmlentities($value, ENT_QUOTES, 'UTF-8', true);
+    }
 
 	////////////////////////////////////////////////////////////////////
 	///////////////////////// LOCALIZATION HELPERS /////////////////////

--- a/src/Former/Helpers.php
+++ b/src/Former/Helpers.php
@@ -33,18 +33,18 @@ class Helpers
 	 *
 	 * @return string
 	 */
-    public static function encode($value)
-    {
-        if ($value === null) {
-            return '';
-        }
+	public static function encode($value)
+	{
+		if ($value === null) {
+			return '';
+		}
 
-        if (is_array($value)) {
-            $value = '';
-        }
+		if (is_array($value)) {
+			$value = '';
+		}
 
-        return htmlentities($value, ENT_QUOTES, 'UTF-8', true);
-    }
+		return htmlentities($value, ENT_QUOTES, 'UTF-8', true);
+	}
 
 	////////////////////////////////////////////////////////////////////
 	///////////////////////// LOCALIZATION HELPERS /////////////////////

--- a/src/Former/Traits/Checkable.php
+++ b/src/Former/Traits/Checkable.php
@@ -257,24 +257,24 @@ abstract class Checkable extends Field
 		return $this;
 	}
 
-    /**
-     * Creates a series of checkable items from query with attributes
-     *
-     * @param mixed $query
-     * @param mixed $text
-     * @param mixed $attributes
-     * @return $this
-     */
-    public function fromQuery($query, $text = null, $attributes = null)
-    {
-        if ($this->isGrouped()) {
-            // Remove any possible items added by the Populator.
-            $this->items = array();
-        }
-        $this->items($query, $text, $attributes);
+	/**
+	 * Creates a series of checkable items from query with attributes
+	 *
+	 * @param mixed $query
+	 * @param mixed $text
+	 * @param mixed $attributes
+	 * @return $this
+	 */
+	public function fromQuery($query, $text = null, $attributes = null)
+	{
+		if ($this->isGrouped()) {
+			// Remove any possible items added by the Populator.
+			$this->items = array();
+		}
+		$this->items($query, $text, $attributes);
 
-        return $this;
-    }
+		return $this;
+	}
 
 	/**
 	 * Check if the checkables are inline
@@ -293,9 +293,11 @@ abstract class Checkable extends Field
 	/**
 	 * Creates a series of checkable items
 	 *
-	 * @param array $_items Items to create
+	 * @param array|Collection $_items Items to create
+	 * @param string|function  $text The value to use as text
+	 * @param string|array     $attributes The data to use as attributes
 	 */
-    protected function items($_items, $text = null, $attributes = null)
+	protected function items($_items, $text = null, $attributes = null)
 	{
 		// If passing an array
 		if (sizeof($_items) == 1 and
@@ -305,13 +307,13 @@ abstract class Checkable extends Field
 			$_items = $_items[0];
 		}
 
-        // Fetch models if that's what we were passed
-        if ((isset($_items[0]) and is_object($_items[0])) or ($_items instanceof Collection)) {
-            $_items = Helpers::queryToArray($_items, $text, $attributes);
-            if (is_null($text) && is_null($attributes)) {
-                $_items = array_flip($_items);
-            }
-        }
+		// Fetch models if that's what we were passed
+		if ((isset($_items[0]) and is_object($_items[0])) or ($_items instanceof Collection)) {
+			$_items = Helpers::queryToArray($_items, $text, $attributes);
+			if (is_null($text) && is_null($attributes)) {
+				$_items = array_flip($_items);
+			}
+		}
 
 		// Iterate through items, assign a name and a label to each
 		$count = 0;
@@ -562,7 +564,7 @@ abstract class Checkable extends Field
 
 		if (!is_null($post) and $post !== $this->app['former']->getOption('unchecked_value')) {
 			$isChecked = ($post == $value);
-        } elseif (!is_null($static) && !(is_array($static) && empty($static))) {
+		} elseif (!is_null($static) && !(is_array($static) && empty($static))) {
 			$isChecked = ($static == $value);
 		} else {
 			$isChecked = $checked;

--- a/src/Former/Traits/Checkable.php
+++ b/src/Former/Traits/Checkable.php
@@ -257,6 +257,24 @@ abstract class Checkable extends Field
 		return $this;
 	}
 
+    /**
+     * Creates a series of checkable items from query with attributes
+     *
+     * @param mixed $query
+     * @param mixed $text
+     * @param mixed $attributes
+     * @return $this
+     */
+    public function fromQuery($query, $text = null, $attributes = null)
+    {
+        if ($this->isGrouped()) {
+            // Remove any possible items added by the Populator.
+            $this->items = array();
+        }
+        $this->items($query, $text, $attributes);
+
+        return $this;
+    }
 
 	/**
 	 * Check if the checkables are inline
@@ -277,7 +295,7 @@ abstract class Checkable extends Field
 	 *
 	 * @param array $_items Items to create
 	 */
-	protected function items($_items)
+    protected function items($_items, $text = null, $attributes = null)
 	{
 		// If passing an array
 		if (sizeof($_items) == 1 and
@@ -287,11 +305,13 @@ abstract class Checkable extends Field
 			$_items = $_items[0];
 		}
 
-		// Fetch models if that's what we were passed
-		if (isset($_items[0]) and is_object($_items[0])) {
-			$_items = Helpers::queryToArray($_items);
-			$_items = array_flip($_items);
-		}
+        // Fetch models if that's what we were passed
+        if ((isset($_items[0]) and is_object($_items[0])) or ($_items instanceof Collection)) {
+            $_items = Helpers::queryToArray($_items, $text, $attributes);
+            if (is_null($text) && is_null($attributes)) {
+                $_items = array_flip($_items);
+            }
+        }
 
 		// Iterate through items, assign a name and a label to each
 		$count = 0;
@@ -542,7 +562,7 @@ abstract class Checkable extends Field
 
 		if (!is_null($post) and $post !== $this->app['former']->getOption('unchecked_value')) {
 			$isChecked = ($post == $value);
-		} elseif (!is_null($static)) {
+        } elseif (!is_null($static) && !(is_array($static) && empty($static))) {
 			$isChecked = ($static == $value);
 		} else {
 			$isChecked = $checked;

--- a/tests/Fields/SelectTest.php
+++ b/tests/Fields/SelectTest.php
@@ -542,4 +542,57 @@ class SelectTest extends FormerTests
 
 		$this->assertStringContainsString($matcher, $select->render());
 	}
+
+    public function testCanClearPreviouslySelectedOptions()
+    {
+        $select = $this->former->select('foo')->options([
+            'One' => ['value' => 1, 'selected' => 'selected'],
+            'Two' => ['value' => 2],
+        ])->select(2);
+
+        $matcher = $this->controlGroup(
+            '<select id="foo" name="foo">'.
+            '<option value="1">One</option>'.
+            '<option value="2" selected="selected">Two</option>'.
+            '</select>'
+        );
+
+        $this->assertEquals($matcher, $select->__toString());
+    }
+
+    public function testOptgroupSupportsNestedOptionsWithAttributes()
+    {
+        $select = $this->former->select('foo')->addOption([
+            'A' => ['value' => 1, 'data-type' => 'x'],
+            'B' => ['value' => 2, 'data-type' => 'y'],
+        ], 'Group 1');
+
+        $matcher = $this->controlGroup(
+            '<select id="foo" name="foo">'.
+            '<optgroup label="Group 1">'.
+            '<option value="1" data-type="x">A</option>'.
+            '<option value="2" data-type="y">B</option>'.
+            '</optgroup>'.
+            '</select>'
+        );
+
+        $this->assertEquals($matcher, $select->__toString());
+    }
+
+    public function testSelectHandlesLooseTypeMatchingForValues()
+    {
+        $select = $this->former->select('foo')->options([
+            'Zero' => ['value' => 0],
+            'One' => ['value' => 1],
+        ])->select('0');
+
+        $matcher = $this->controlGroup(
+            '<select id="foo" name="foo">'.
+            '<option value="0" selected="selected">Zero</option>'.
+            '<option value="1">One</option>'.
+            '</select>'
+        );
+
+        $this->assertEquals($matcher, $select->__toString());
+    }
 }

--- a/tests/Fields/SelectTest.php
+++ b/tests/Fields/SelectTest.php
@@ -543,56 +543,56 @@ class SelectTest extends FormerTests
 		$this->assertStringContainsString($matcher, $select->render());
 	}
 
-    public function testCanClearPreviouslySelectedOptions()
-    {
-        $select = $this->former->select('foo')->options([
-            'One' => ['value' => 1, 'selected' => 'selected'],
-            'Two' => ['value' => 2],
-        ])->select(2);
+	public function testCanClearPreviouslySelectedOptions()
+	{
+		$select = $this->former->select('foo')->options([
+			'One' => ['value' => 1, 'selected' => 'selected'],
+			'Two' => ['value' => 2],
+		])->select(2);
 
-        $matcher = $this->controlGroup(
-            '<select id="foo" name="foo">'.
-            '<option value="1">One</option>'.
-            '<option value="2" selected="selected">Two</option>'.
-            '</select>'
-        );
+		$matcher = $this->controlGroup(
+			'<select id="foo" name="foo">' .
+			'<option value="1">One</option>' .
+			'<option value="2" selected="selected">Two</option>' .
+			'</select>'
+		);
 
-        $this->assertEquals($matcher, $select->__toString());
-    }
+		$this->assertEquals($matcher, $select->__toString());
+	}
 
-    public function testOptgroupSupportsNestedOptionsWithAttributes()
-    {
-        $select = $this->former->select('foo')->addOption([
-            'A' => ['value' => 1, 'data-type' => 'x'],
-            'B' => ['value' => 2, 'data-type' => 'y'],
-        ], 'Group 1');
+	public function testOptgroupSupportsNestedOptionsWithAttributes()
+	{
+		$select = $this->former->select('foo')->addOption([
+			'A' => ['value' => 1, 'data-type' => 'x'],
+			'B' => ['value' => 2, 'data-type' => 'y'],
+		], 'Group 1');
 
-        $matcher = $this->controlGroup(
-            '<select id="foo" name="foo">'.
-            '<optgroup label="Group 1">'.
-            '<option value="1" data-type="x">A</option>'.
-            '<option value="2" data-type="y">B</option>'.
-            '</optgroup>'.
-            '</select>'
-        );
+		$matcher = $this->controlGroup(
+			'<select id="foo" name="foo">' .
+			'<optgroup label="Group 1">' .
+			'<option value="1" data-type="x">A</option>' .
+			'<option value="2" data-type="y">B</option>' .
+			'</optgroup>' .
+			'</select>'
+		);
 
-        $this->assertEquals($matcher, $select->__toString());
-    }
+		$this->assertEquals($matcher, $select->__toString());
+	}
 
-    public function testSelectHandlesLooseTypeMatchingForValues()
-    {
-        $select = $this->former->select('foo')->options([
-            'Zero' => ['value' => 0],
-            'One' => ['value' => 1],
-        ])->select('0');
+	public function testSelectHandlesLooseTypeMatchingForValues()
+	{
+		$select = $this->former->select('foo')->options([
+			'Zero' => ['value' => 0],
+			'One' => ['value' => 1],
+		])->select('0');
 
-        $matcher = $this->controlGroup(
-            '<select id="foo" name="foo">'.
-            '<option value="0" selected="selected">Zero</option>'.
-            '<option value="1">One</option>'.
-            '</select>'
-        );
+		$matcher = $this->controlGroup(
+			'<select id="foo" name="foo">' .
+			'<option value="0" selected="selected">Zero</option>' .
+			'<option value="1">One</option>' .
+			'</select>'
+		);
 
-        $this->assertEquals($matcher, $select->__toString());
-    }
+		$this->assertEquals($matcher, $select->__toString());
+	}
 }


### PR DESCRIPTION
This merge request introduces multiple improvements and bugfixes for the Select and Checkable field components:

Select (Former\Form\Fields\Select)

Fixed an edge case where previously selected values could persist due to missing state reset:

Added clearSelected() method to ensure no stale selected attributes remain before rendering.

Improved type-safety when comparing numeric values:

Comparison logic in selectValue() now safely handles both strings and integers using strict coercion.

Enhanced addOption() to support optgroup with nested options that include attributes (not just text).

Preserved backward compatibility by retaining existing behavior unless extra attributes are passed.

Checkable (Former\Traits\Checkable)

Restored and improved the fromQuery() method:

Now supports passing closures for $text and $attributes, consistent with Select::fromQuery().

Refactored internal items() method:

Accepts Eloquent/Fluent collections and converts them using Helpers::queryToArray().

Now matches behavior of Select, including array_flip() fallback for simpler usage.

This change enables developers to build dynamic radio() and checkbox() groups using collection-driven definitions, without requiring external transformation logic.